### PR TITLE
RMQ fail-fast

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.21'
     ext.ktor_version = '1.0.0'
-    ext.notary_version='54a4015acf77e18c7b1629d27a3996d08436fc30'
+    ext.notary_version='8a6f5c0e8e'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
The withdrawal service will exit on RMQ failure. Testing is not possible at this moment since there is no way to map default RMQ port to another port.