### PR TITLE
Fixed rollback

### DIFF
--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewSignatureEventHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewSignatureEventHandler.kt
@@ -100,6 +100,7 @@ class NewSignatureEventHandler(
                 })
 
         }, { ex ->
+            transactionHelper.unregisterUnspents(originalHash)
             btcRollbackService.rollback(
                 withdrawalCommand.sourceAccountId,
                 withdrawalCommand.amountSat,


### PR DESCRIPTION
We must unregister(free) BTC UTXO in case of Iroha error.