### PR TITLE
Fixed SharedPeerGroup

### DIFF
--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
@@ -10,6 +10,7 @@ import com.d3.btc.handler.NewBtcClientRegistrationHandler
 import com.d3.btc.healthcheck.HealthyService
 import com.d3.btc.helper.network.addPeerConnectionStatusListener
 import com.d3.btc.helper.network.startChainDownload
+import com.d3.btc.peer.SharedPeerGroup
 import com.d3.btc.provider.BtcChangeAddressProvider
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.wallet.checkWalletNetwork
@@ -46,7 +47,7 @@ import java.io.File
 @Component
 class BtcWithdrawalInitialization(
     @Autowired private val btcWithdrawalConfig: BtcWithdrawalConfig,
-    @Autowired private val peerGroup: PeerGroup,
+    @Autowired private val peerGroup: SharedPeerGroup,
     @Autowired private val transferWallet: Wallet,
     @Autowired private val btcChangeAddressProvider: BtcChangeAddressProvider,
     @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider,

--- a/btc/src/main/kotlin/com/d3/btc/helper/network/BitcoinNetworkHelper.kt
+++ b/btc/src/main/kotlin/com/d3/btc/helper/network/BitcoinNetworkHelper.kt
@@ -5,6 +5,7 @@
 
 package com.d3.btc.helper.network
 
+import com.d3.btc.peer.SharedPeerGroup
 import mu.KLogging
 import org.bitcoinj.core.BlockChain
 import org.bitcoinj.core.Context
@@ -19,10 +20,11 @@ private val logger = KLogging().logger
 /**
  * Starts bitcoin blockchain downloading process
  */
-fun startChainDownload(peerGroup: PeerGroup) {
-    logger.info { "Start bitcoin blockchain download" }
+fun startChainDownload(peerGroup: SharedPeerGroup) {
+    logger.info("Start blockchain download")
     peerGroup.startAsync()
-    peerGroup.downloadBlockChain()
+    peerGroup.awaitDownload()
+    logger.info("Done downloading blockchain")
 }
 
 /**

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
@@ -122,7 +122,7 @@ class BtcDepositFailResistanceIntegrationTest {
         //Creates peer group
         val peerGroup = environment.createPeerGroup(transfersWallet)
         peerGroup.startAsync()
-        peerGroup.downloadBlockChain()
+        peerGroup.awaitDownload()
         //Send coins and confirm it with exactly one block
         integrationHelper.sendBtc(
             depositAddress,


### PR DESCRIPTION
`startAsync()` and `downloadBlockChain()` must be called atomically to avoid multithread issues.