### PR TITLE
Peer discovery

### DIFF
--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
@@ -234,4 +234,7 @@ class BtcDWBridgeAppConfiguration {
     @Bean
     fun serviceExpansion() =
         ServiceExpansion(dwBridgeConfig.expansionTriggerAccount, irohaAPI())
+
+    @Bean
+    fun dnsSeed() = dwBridgeConfig.dnsSeedAddress
 }

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeConfig.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeConfig.kt
@@ -17,4 +17,6 @@ interface BtcDWBridgeConfig {
     val iroha: IrohaConfig
 
     val healthCheckPort: Int
+
+    val dnsSeedAddress: String?
 }

--- a/btc-dw-bridge/src/main/resources/dw-bridge_mainnet.properties
+++ b/btc-dw-bridge/src/main/resources/dw-bridge_mainnet.properties
@@ -9,3 +9,4 @@ btc-dw-bridge.bitcoin.confidenceLevel=6
 btc-dw-bridge.bitcoin.hosts=85.236.188.65,46.188.126.74,58.246.136.250
 btc-dw-bridge.healthCheckPort=7074
 btc-dw-bridge.expansionTriggerAccount=expansion_trigger@notary
+btc-dw-bridge.dnsSeedAddress=seed.bitcoin.sipa.be

--- a/btc-dw-bridge/src/main/resources/dw-bridge_testnet.properties
+++ b/btc-dw-bridge/src/main/resources/dw-bridge_testnet.properties
@@ -9,3 +9,4 @@ btc-dw-bridge.bitcoin.confidenceLevel=0
 btc-dw-bridge.bitcoin.hosts=d3-btc-node0
 btc-dw-bridge.healthCheckPort=7074
 btc-dw-bridge.expansionTriggerAccount=expansion_trigger@notary
+btc-dw-bridge.dnsSeedAddress=testnet-seed.bitcoin.jonasschnelli.ch

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcIntegrationHelperUtil.kt
@@ -169,6 +169,7 @@ class BtcIntegrationHelperUtil(peers: Int = 1) : IrohaIntegrationHelperUtil(peer
             wallet,
             blockStoragePath,
             hosts,
+            null,
             walletInitializer
         )
     }


### PR DESCRIPTION
Having one and the only connected peer is not enough to make Bitcoin subsystem stable. Thankfully, bitcoinj provides peer discovery mechanisms. Just set a DNS seed server address (a DNS server which returns IP addresses of full nodes).