### PR TITLE
Storing broadcasts

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/expansion/AddressGenerationServiceExpansion.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/expansion/AddressGenerationServiceExpansion.kt
@@ -23,11 +23,11 @@ class AddressGenerationServiceExpansion(
 ) {
 
     fun expand(block: BlockOuterClass.Block) {
-        serviceExpansion.expand(block) { expansiontDetails, _, triggerTime ->
+        serviceExpansion.expand(block) { expansionsDetails, _, triggerTime ->
             ExpansionUtils.addSignatureExpansionLogic(
                 irohaAPI,
                 mstRegistrationCredential,
-                expansiontDetails,
+                expansionsDetails,
                 triggerTime
             )
         }

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/expansion/DepositServiceExpansion.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/expansion/DepositServiceExpansion.kt
@@ -22,11 +22,11 @@ class DepositServiceExpansion(
 ) {
 
     fun expand(block: BlockOuterClass.Block) {
-        serviceExpansion.expand(block) { expansiontDetails, _, triggerTime ->
+        serviceExpansion.expand(block) { expansionsDetails, _, triggerTime ->
             ExpansionUtils.addSignatureExpansionLogic(
                 irohaAPI,
                 notaryCredential,
-                expansiontDetails,
+                expansionsDetails,
                 triggerTime
             )
         }

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
@@ -78,6 +78,14 @@ class BtcDWBridgeAppConfiguration {
             )
         )
 
+    private val broadcastCredential =
+        IrohaCredential(
+            withdrawalConfig.broadcastsCredential.accountId, Utils.parseHexKeypair(
+                withdrawalConfig.broadcastsCredential.pubkey,
+                withdrawalConfig.broadcastsCredential.privkey
+            )
+        )
+
     private val notaryCredential =
         IrohaCredential(depositConfig.notaryCredential.accountId, notaryKeypair)
 
@@ -187,6 +195,9 @@ class BtcDWBridgeAppConfiguration {
     fun withdrawalConsumer() = IrohaConsumerImpl(withdrawalCredential(), irohaAPI())
 
     @Bean
+    fun withdrawalConsumerMultiSig() = MultiSigIrohaConsumer(withdrawalCredential(), irohaAPI())
+
+    @Bean
     fun withdrawalConfig() = withdrawalConfig
 
     @Bean
@@ -195,6 +206,9 @@ class BtcDWBridgeAppConfiguration {
         dwBridgeConfig.iroha.port,
         notaryCredential
     )
+
+    @Bean
+    fun broadcastsIrohaConsumer() = IrohaConsumerImpl(broadcastCredential, irohaAPI())
 
     @Bean
     fun withdrawalQueryHelper() =

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalConfig.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/config/BtcWithdrawalConfig.kt
@@ -13,6 +13,8 @@ const val BTC_WITHDRAWAL_SERVICE_NAME = "btc-withdrawal"
 interface BtcWithdrawalConfig {
     // Account that handles withdrawal events
     val withdrawalCredential: IrohaCredentialRawConfig
+    // Account that stores withdrawal broadcasts
+    val broadcastsCredential: IrohaCredentialRawConfig
     // Account that stores Bitcoin transaction signatures
     val signatureCollectorCredential: IrohaCredentialRawConfig
     // Account that is used to deal with registered accounts

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/expansion/WithdrawalServiceExpansion.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/expansion/WithdrawalServiceExpansion.kt
@@ -22,11 +22,11 @@ class WithdrawalServiceExpansion(
 ) {
 
     fun expand(block: BlockOuterClass.Block) {
-        serviceExpansion.expand(block) { expansiontDetails, _, triggerTime ->
+        serviceExpansion.expand(block) { expansionDetails, _, triggerTime ->
             ExpansionUtils.addSignatureExpansionLogic(
                 irohaAPI,
                 withdrawalCredential,
-                expansiontDetails,
+                expansionDetails,
                 triggerTime
             )
         }

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
@@ -1,13 +1,18 @@
 package com.d3.btc.withdrawal.handler
 
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
+import com.d3.btc.withdrawal.provider.BroadcastsProvider
+import com.d3.btc.withdrawal.provider.UTXOProvider
 import com.d3.btc.withdrawal.service.BtcRollbackService
 import com.d3.btc.withdrawal.transaction.SignCollector
 import com.d3.btc.withdrawal.transaction.TransactionsStorage
+import com.d3.btc.withdrawal.transaction.WithdrawalDetails
 import com.github.kittinunf.result.failure
+import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
 import iroha.protocol.Commands
 import mu.KLogging
+import org.bitcoinj.core.Transaction
 import org.springframework.stereotype.Component
 
 @Component
@@ -15,7 +20,9 @@ class NewTransactionCreatedHandler(
     private val signCollector: SignCollector,
     private val transactionsStorage: TransactionsStorage,
     private val btcWithdrawalConfig: BtcWithdrawalConfig,
-    private val btcRollbackService: BtcRollbackService
+    private val btcRollbackService: BtcRollbackService,
+    private val bitcoinUTXOProvider: UTXOProvider,
+    private val broadcastsProvider: BroadcastsProvider
 ) {
 
     /**
@@ -26,20 +33,38 @@ class NewTransactionCreatedHandler(
         createNewTxCommand: Commands.SetAccountDetail
     ) {
         val txHash = createNewTxCommand.key
-        transactionsStorage.get(createNewTxCommand.key).map { (withdrawalDetails, transaction) ->
-            logger.info { "Tx to sign\n$transaction" }
-            signCollector.signAndSave(transaction, btcWithdrawalConfig.btcKeysWalletPath).fold({
-                logger.info { "Signatures for ${transaction.hashAsString} were successfully processed" }
-            }, { ex ->
-                logger.error("Cannot sign transaction $transaction", ex)
+        var savedWithdrawalDetails: WithdrawalDetails? = null
+        var savedTransaction: Transaction? = null
+        transactionsStorage.get(txHash).map { (withdrawalDetails, transaction) ->
+            savedWithdrawalDetails = withdrawalDetails
+            savedTransaction = transaction
+        }.flatMap {
+            broadcastsProvider.hasBeenBroadcasted(savedWithdrawalDetails!!)
+        }.map { broadcasted ->
+            if (broadcasted) {
+                logger.info("Withdrawal $savedWithdrawalDetails has been broadcasted before")
+                return@map
+            }
+            val transaction = savedTransaction!!
+            logger.info { "Tx to sign\n$savedTransaction" }
+            signCollector.signAndSave(transaction, btcWithdrawalConfig.btcKeysWalletPath)
+        }.map {
+            logger.info { "Signatures for ${savedTransaction!!.hashAsString} were successfully processed" }
+        }.failure { ex ->
+            if (savedTransaction != null && savedWithdrawalDetails != null) {
+                logger.error("Cannot handle new transaction $savedTransaction", ex)
                 btcRollbackService.rollback(
-                    withdrawalDetails.sourceAccountId,
-                    withdrawalDetails.amountSat,
-                    withdrawalDetails.withdrawalTime,
+                    savedWithdrawalDetails!!.sourceAccountId,
+                    savedWithdrawalDetails!!.amountSat,
+                    savedWithdrawalDetails!!.withdrawalTime,
                     "Cannot sign"
                 )
-            })
-        }.failure { ex -> logger.error("Cannot get transaction from Iroha by hash ${txHash}", ex) }
+                bitcoinUTXOProvider.unregisterUnspents(savedTransaction!!, savedWithdrawalDetails!!)
+                    .failure { e -> NewSignatureEventHandler.logger.error("Cannot unregister unspents", e) }
+            } else {
+                logger.error("Cannot handle new transaction with hash $txHash", ex)
+            }
+        }
     }
 
     /**

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/provider/BroadcastsProvider.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/provider/BroadcastsProvider.kt
@@ -1,0 +1,71 @@
+package com.d3.btc.withdrawal.provider
+
+import com.d3.btc.withdrawal.transaction.WithdrawalDetails
+import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
+import com.d3.commons.sidechain.iroha.util.IrohaQueryHelper
+import com.d3.commons.sidechain.iroha.util.ModelUtil
+import com.github.kittinunf.result.Result
+import com.github.kittinunf.result.map
+import mu.KLogging
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Component
+
+/**
+ * Provider that is used to mark withdrawals as 'broadcasted'
+ */
+@Component
+class BroadcastsProvider(
+    @Qualifier("broadcastsIrohaConsumer")
+    private val broadcastsIrohaConsumer: IrohaConsumer,
+    @Qualifier("withdrawalQueryHelper")
+    private val withdrawalQueryHelper: IrohaQueryHelper
+) {
+
+    /**
+     * Checks if given withdrawal has been broadcasted before
+     * @param withdrawalDetails - details of withdrawal
+     * @return true if given withdrawal has been broadcasted before
+     */
+    fun hasBeenBroadcasted(withdrawalDetails: WithdrawalDetails): Result<Boolean, Exception> {
+        logger.info("Check if withdrawal $withdrawalDetails (hash ${withdrawalDetails.irohaFriendlyHashCode()}) has been broadcasted")
+        return hasBeenBroadcasted(withdrawalDetails.irohaFriendlyHashCode())
+    }
+
+    /**
+     * Checks if given withdrawal has been broadcasted before
+     * @param withdrawalHash - hash code of withdrawal
+     * @return true if given withdrawal has been broadcasted before
+     */
+    fun hasBeenBroadcasted(withdrawalHash: String): Result<Boolean, Exception> {
+        return withdrawalQueryHelper.getAccountDetails(
+            broadcastsIrohaConsumer.creator,
+            broadcastsIrohaConsumer.creator,
+            withdrawalHash
+        ).map { value ->
+            val broadcasted = value.isPresent
+            if (broadcasted) {
+                logger.info("Withdrawal with hash $withdrawalHash has been broadcasted already")
+            } else {
+                logger.info("Withdrawal with hash $withdrawalHash hasn't been broadcasted yet")
+            }
+            broadcasted
+        }
+    }
+
+    /**
+     * Marks given withdrawal as 'broadcasted'
+     * @param withdrawalDetails - withdrawal to mark
+     * @return result of operation
+     */
+    fun markAsBroadcasted(withdrawalDetails: WithdrawalDetails): Result<Unit, Exception> {
+        logger.info("Mark withdrawal $withdrawalDetails as 'broadcasted'")
+        return ModelUtil.setAccountDetail(
+            broadcastsIrohaConsumer,
+            broadcastsIrohaConsumer.creator,
+            withdrawalDetails.irohaFriendlyHashCode(),
+            ""
+        ).map { Unit }
+    }
+
+    companion object : KLogging()
+}

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/service/BtcRollbackService.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/service/BtcRollbackService.kt
@@ -8,6 +8,7 @@ package com.d3.btc.withdrawal.service
 import com.d3.btc.helper.currency.satToBtc
 import com.d3.btc.withdrawal.transaction.WithdrawalDetails
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
+import com.d3.commons.sidechain.iroha.consumer.MultiSigIrohaConsumer
 import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.github.kittinunf.result.flatMap
 import mu.KLogging
@@ -22,8 +23,8 @@ private const val BTC_ASSET_ID = "btc#bitcoin"
  */
 @Component
 class BtcRollbackService(
-    @Qualifier("withdrawalConsumer")
-    @Autowired private val withdrawalConsumer: IrohaConsumer
+    @Qualifier("withdrawalConsumerMultiSig")
+    private val withdrawalConsumer: MultiSigIrohaConsumer
 ) {
 
     /**

--- a/btc-withdrawal/src/main/resources/withdrawal_local.properties
+++ b/btc-withdrawal/src/main/resources/withdrawal_local.properties
@@ -9,6 +9,10 @@ btc-withdrawal.irohaBlockQueue=btc_withdrawal_blocks
 btc-withdrawal.btcTransfersWalletPath=deploy/bitcoin/regtest/transfers.d3.wallet
 btc-withdrawal.btcKeysWalletPath=deploy/bitcoin/regtest/keys.d3.wallet
 # --------- Credentials -------
+btc-withdrawal.broadcastsCredential.accountId=broadcast@notary
+btc-withdrawal.broadcastsCredential.pubkey=e48e003991142b90a3569d6804738c69296f339216166a3e6d20d6380afb25b1
+btc-withdrawal.broadcastsCredential.privkey=17f08b291bec13817c8d8424608e6848460d209c71ab882243a8e8a9daebd092
+# --------- Credentials -------
 btc-withdrawal.withdrawalCredential.accountId=btc_withdrawal_service@notary
 btc-withdrawal.withdrawalCredential.pubkey=2ea1d2c3eb5b35a85b393622609ae116ddb2ea35e060fc74adb3b2caa324eacb
 btc-withdrawal.withdrawalCredential.privkey=3b12d8ed2e56db58a7d622204145252a4487b9afbb63059eb7d2bbbe5b8e2498

--- a/btc-withdrawal/src/main/resources/withdrawal_mainnet.properties
+++ b/btc-withdrawal/src/main/resources/withdrawal_mainnet.properties
@@ -9,6 +9,10 @@ btc-withdrawal.irohaBlockQueue=btc_withdrawal_blocks
 btc-withdrawal.btcTransfersWalletPath=deploy/bitcoin/mainnet/transfers.d3.wallet
 btc-withdrawal.btcKeysWalletPath=deploy/bitcoin/mainnet/keys.d3.wallet
 # --------- Credentials -------
+btc-withdrawal.broadcastsCredential.accountId=broadcast@notary
+btc-withdrawal.broadcastsCredential.pubkey=e48e003991142b90a3569d6804738c69296f339216166a3e6d20d6380afb25b1
+btc-withdrawal.broadcastsCredential.privkey=17f08b291bec13817c8d8424608e6848460d209c71ab882243a8e8a9daebd092
+# --------- Credentials -------
 btc-withdrawal.withdrawalCredential.accountId=btc_withdrawal_service@notary
 btc-withdrawal.withdrawalCredential.pubkey=2ea1d2c3eb5b35a85b393622609ae116ddb2ea35e060fc74adb3b2caa324eacb
 btc-withdrawal.withdrawalCredential.privkey=3b12d8ed2e56db58a7d622204145252a4487b9afbb63059eb7d2bbbe5b8e2498

--- a/btc-withdrawal/src/main/resources/withdrawal_testnet.properties
+++ b/btc-withdrawal/src/main/resources/withdrawal_testnet.properties
@@ -9,6 +9,10 @@ btc-withdrawal.irohaBlockQueue=btc_withdrawal_blocks
 btc-withdrawal.btcTransfersWalletPath=deploy/bitcoin/testnet/transfers.d3.wallet
 btc-withdrawal.btcKeysWalletPath=deploy/bitcoin/testnet/keys.d3.wallet
 # --------- Credentials -------
+btc-withdrawal.broadcastsCredential.accountId=broadcast@notary
+btc-withdrawal.broadcastsCredential.pubkey=e48e003991142b90a3569d6804738c69296f339216166a3e6d20d6380afb25b1
+btc-withdrawal.broadcastsCredential.privkey=17f08b291bec13817c8d8424608e6848460d209c71ab882243a8e8a9daebd092
+# --------- Credentials -------
 btc-withdrawal.withdrawalCredential.accountId=btc_withdrawal_service@notary
 btc-withdrawal.withdrawalCredential.pubkey=2ea1d2c3eb5b35a85b393622609ae116ddb2ea35e060fc74adb3b2caa324eacb
 btc-withdrawal.withdrawalCredential.privkey=3b12d8ed2e56db58a7d622204145252a4487b9afbb63059eb7d2bbbe5b8e2498

--- a/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewSignatureEventHandlerTest.java
+++ b/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewSignatureEventHandlerTest.java
@@ -1,0 +1,89 @@
+package com.d3.btc.withdrawal.handler;
+
+import com.d3.btc.withdrawal.provider.BroadcastsProvider;
+import com.d3.btc.withdrawal.provider.UTXOProvider;
+import com.d3.btc.withdrawal.service.BtcRollbackService;
+import com.d3.btc.withdrawal.statistics.WithdrawalStatistics;
+import com.d3.btc.withdrawal.transaction.SignCollector;
+import com.d3.btc.withdrawal.transaction.TransactionsStorage;
+import com.d3.btc.withdrawal.transaction.WithdrawalDetails;
+import com.github.kittinunf.result.Result;
+import iroha.protocol.Commands;
+import kotlin.Pair;
+import org.bitcoinj.core.PeerGroup;
+import org.bitcoinj.core.Transaction;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.d3.commons.sidechain.iroha.IrohaValsKt.BTC_SIGN_COLLECT_DOMAIN;
+import static org.mockito.Mockito.*;
+
+public class NewSignatureEventHandlerTest {
+
+    /**
+     * @given instance of NewSignatureEventHandler with BroadcastsProvider that returns true whenever hasBeenBroadcasted() is called
+     * @when handleNewSignatureCommand() is called
+     * @then broadcastIfEnoughSignatures() is not called
+     */
+    @Test
+    public void testHandleNewSignatureCommandHasBeenBroadcasted() {
+        WithdrawalStatistics withdrawalStatistics = new WithdrawalStatistics(new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+        SignCollector signCollector = mock(SignCollector.class);
+        TransactionsStorage transactionsStorage = mock(TransactionsStorage.class);
+        WithdrawalDetails withdrawalDetails = new WithdrawalDetails("src account id", "to address", 0, System.currentTimeMillis());
+        Transaction transaction = mock(Transaction.class);
+        Pair<WithdrawalDetails, Transaction> withdrawal = new Pair<>(withdrawalDetails, transaction);
+        when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> withdrawal));
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        PeerGroup peerGroup = mock(PeerGroup.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> true));
+        NewSignatureEventHandler newSignatureEventHandler = spy(new NewSignatureEventHandler(
+                withdrawalStatistics,
+                signCollector,
+                transactionsStorage,
+                utxoProvider,
+                btcRollbackService,
+                peerGroup,
+                broadcastsProvider));
+        doNothing().when(newSignatureEventHandler).broadcastIfEnoughSignatures(any(), any(), any());
+        Commands.SetAccountDetail newSignatureDetail = Commands.SetAccountDetail.newBuilder().setAccountId("test@" + BTC_SIGN_COLLECT_DOMAIN).build();
+        newSignatureEventHandler.handleNewSignatureCommand(newSignatureDetail, () -> null);
+        verify(newSignatureEventHandler, never()).broadcastIfEnoughSignatures(any(), any(), any());
+    }
+
+    /**
+     * @given instance of NewSignatureEventHandler with BroadcastsProvider that returns false whenever hasBeenBroadcasted() is called
+     * @when handleNewSignatureCommand() is called
+     * @then broadcastIfEnoughSignatures() is called
+     */
+    @Test
+    public void testHandleNewSignatureCommandHasNotBeenBroadcasted() {
+        WithdrawalStatistics withdrawalStatistics = new WithdrawalStatistics(new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+        SignCollector signCollector = mock(SignCollector.class);
+        TransactionsStorage transactionsStorage = mock(TransactionsStorage.class);
+        WithdrawalDetails withdrawalDetails = new WithdrawalDetails("src account id", "to address", 0, System.currentTimeMillis());
+        Transaction transaction = mock(Transaction.class);
+        Pair<WithdrawalDetails, Transaction> withdrawal = new Pair<>(withdrawalDetails, transaction);
+        when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> withdrawal));
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        PeerGroup peerGroup = mock(PeerGroup.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> false));
+        NewSignatureEventHandler newSignatureEventHandler = spy(new NewSignatureEventHandler(
+                withdrawalStatistics,
+                signCollector,
+                transactionsStorage,
+                utxoProvider,
+                btcRollbackService,
+                peerGroup,
+                broadcastsProvider));
+        doNothing().when(newSignatureEventHandler).broadcastIfEnoughSignatures(any(), any(), any());
+        Commands.SetAccountDetail newSignatureDetail = Commands.SetAccountDetail.newBuilder().setAccountId("test@" + BTC_SIGN_COLLECT_DOMAIN).build();
+        newSignatureEventHandler.handleNewSignatureCommand(newSignatureDetail, () -> null);
+        verify(newSignatureEventHandler).broadcastIfEnoughSignatures(any(), any(), any());
+    }
+}

--- a/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandlerTest.java
+++ b/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandlerTest.java
@@ -1,0 +1,93 @@
+package com.d3.btc.withdrawal.handler;
+
+import com.d3.btc.withdrawal.config.BtcWithdrawalConfig;
+import com.d3.btc.withdrawal.provider.BroadcastsProvider;
+import com.d3.btc.withdrawal.provider.UTXOProvider;
+import com.d3.btc.withdrawal.service.BtcRollbackService;
+import com.d3.btc.withdrawal.transaction.SignCollector;
+import com.d3.btc.withdrawal.transaction.TransactionsStorage;
+import com.d3.btc.withdrawal.transaction.WithdrawalDetails;
+import com.github.kittinunf.result.Result;
+import iroha.protocol.Commands;
+import kotlin.Pair;
+import org.bitcoinj.core.Transaction;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class NewTransactionCreatedHandlerTest {
+
+    /**
+     * @given instance of NewTransactionCreatedHandler with BroadcastsProvider that returns true whenever hasBeenBroadcasted() is called
+     * @when handleCreateTransactionCommand() is called
+     * @then transactions are ignored and not signed
+     */
+    @Test
+    public void testHandleCreateTransactionCommandHasBeenBroadcasted() {
+        SignCollector signCollector = mock(SignCollector.class);
+        TransactionsStorage transactionsStorage = mock(TransactionsStorage.class);
+        when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> {
+            WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
+                    "source account",
+                    "destination address",
+                    1,
+                    System.currentTimeMillis());
+            Transaction transaction = mock(Transaction.class);
+            return new Pair<>(withdrawalDetails, transaction);
+        }));
+        BtcWithdrawalConfig btcWithdrawalConfig = mock(BtcWithdrawalConfig.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> true));
+        NewTransactionCreatedHandler newTransactionCreatedHandler = new NewTransactionCreatedHandler(
+                signCollector,
+                transactionsStorage,
+                btcWithdrawalConfig,
+                btcRollbackService,
+                utxoProvider,
+                broadcastsProvider);
+
+        Commands.SetAccountDetail createdTxCommand = Commands.SetAccountDetail.newBuilder().setKey("abc").build();
+        newTransactionCreatedHandler.handleCreateTransactionCommand(createdTxCommand);
+        verify(signCollector, never()).signAndSave(any(), any());
+    }
+
+    /**
+     * @given instance of NewTransactionCreatedHandler with BroadcastsProvider that returns false whenever hasBeenBroadcasted() is called
+     * @when handleCreateTransactionCommand() is called
+     * @then transactions are signed
+     */
+    @Test
+    public void testHandleCreateTransactionCommandHasNotBeenBroadcasted() {
+        SignCollector signCollector = mock(SignCollector.class);
+        TransactionsStorage transactionsStorage = mock(TransactionsStorage.class);
+        when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> {
+            WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
+                    "source account",
+                    "destination address",
+                    1,
+                    System.currentTimeMillis());
+            Transaction transaction = mock(Transaction.class);
+            return new Pair<>(withdrawalDetails, transaction);
+        }));
+        BtcWithdrawalConfig btcWithdrawalConfig = mock(BtcWithdrawalConfig.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        UTXOProvider utxoProvider = mock(UTXOProvider.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> false));
+        NewTransactionCreatedHandler newTransactionCreatedHandler = new NewTransactionCreatedHandler(
+                signCollector,
+                transactionsStorage,
+                btcWithdrawalConfig,
+                btcRollbackService,
+                utxoProvider,
+                broadcastsProvider);
+
+        Commands.SetAccountDetail createdTxCommand = Commands.SetAccountDetail.newBuilder().setKey("abc").build();
+        newTransactionCreatedHandler.handleCreateTransactionCommand(createdTxCommand);
+        verify(signCollector, times(1)).signAndSave(any(), any());
+    }
+}

--- a/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransferHandlerTest.java
+++ b/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransferHandlerTest.java
@@ -1,0 +1,85 @@
+package com.d3.btc.withdrawal.handler;
+
+import com.d3.btc.withdrawal.config.BtcWithdrawalConfig;
+import com.d3.btc.withdrawal.provider.BroadcastsProvider;
+import com.d3.btc.withdrawal.provider.WithdrawalConsensusProvider;
+import com.d3.btc.withdrawal.service.BtcRollbackService;
+import com.d3.btc.withdrawal.statistics.WithdrawalStatistics;
+import com.d3.btc.withdrawal.transaction.WithdrawalDetails;
+import com.d3.commons.config.IrohaCredentialRawConfig;
+import com.github.kittinunf.result.Result;
+import iroha.protocol.Commands;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class NewTransferHandlerTest {
+
+    /**
+     * @given instance of NewTransferHandler with mocked BroadcastsProvider that always returns true whenever hasBeenBroadcasted() is called
+     * @when handleTransferCommand() is called
+     * @then checkAndStartConsensus() is not called
+     */
+    @Test
+    public void testHandleTransferCommandHasBeenBroadcasted() {
+        String btcServiceAccount = "btcService@btc";
+        IrohaCredentialRawConfig irohaCredentialRawConfig = mock(IrohaCredentialRawConfig.class);
+        when(irohaCredentialRawConfig.getAccountId()).thenReturn(btcServiceAccount);
+        WithdrawalStatistics withdrawalStatistics = new WithdrawalStatistics(new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+        BtcWithdrawalConfig btcWithdrawalConfig = mock(BtcWithdrawalConfig.class);
+        when(btcWithdrawalConfig.getWithdrawalCredential()).thenReturn(irohaCredentialRawConfig);
+        WithdrawalConsensusProvider withdrawalConsensusProvider = mock(WithdrawalConsensusProvider.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> true));
+        NewTransferHandler handler = spy(new NewTransferHandler(
+                withdrawalStatistics,
+                btcWithdrawalConfig,
+                withdrawalConsensusProvider,
+                btcRollbackService,
+                broadcastsProvider));
+        doNothing().when(handler).checkAndStartConsensus(any());
+        Commands.TransferAsset transferAsset = Commands.TransferAsset.newBuilder()
+                .setDestAccountId(btcServiceAccount)
+                .setAmount("1")
+                .build();
+        handler.handleTransferCommand(transferAsset, System.currentTimeMillis());
+        verify(handler, never()).checkAndStartConsensus(any());
+    }
+
+
+    /**
+     * @given instance of NewTransferHandler with mocked BroadcastsProvider that always returns false whenever hasBeenBroadcasted() is called
+     * @when handleTransferCommand() is called
+     * @then checkAndStartConsensus() is called
+     */
+    @Test
+    public void testHandleTransferCommandHasNotBeenBroadcasted() {
+        String btcServiceAccount = "btcService@btc";
+        IrohaCredentialRawConfig irohaCredentialRawConfig = mock(IrohaCredentialRawConfig.class);
+        when(irohaCredentialRawConfig.getAccountId()).thenReturn(btcServiceAccount);
+        WithdrawalStatistics withdrawalStatistics = new WithdrawalStatistics(new AtomicInteger(), new AtomicInteger(), new AtomicInteger());
+        BtcWithdrawalConfig btcWithdrawalConfig = mock(BtcWithdrawalConfig.class);
+        when(btcWithdrawalConfig.getWithdrawalCredential()).thenReturn(irohaCredentialRawConfig);
+        WithdrawalConsensusProvider withdrawalConsensusProvider = mock(WithdrawalConsensusProvider.class);
+        BtcRollbackService btcRollbackService = mock(BtcRollbackService.class);
+        BroadcastsProvider broadcastsProvider = mock(BroadcastsProvider.class);
+        when(broadcastsProvider.hasBeenBroadcasted(any(WithdrawalDetails.class))).thenReturn(Result.Companion.of(() -> false));
+        NewTransferHandler handler = spy(new NewTransferHandler(
+                withdrawalStatistics,
+                btcWithdrawalConfig,
+                withdrawalConsensusProvider,
+                btcRollbackService,
+                broadcastsProvider));
+        doNothing().when(handler).checkAndStartConsensus(any());
+        Commands.TransferAsset transferAsset = Commands.TransferAsset.newBuilder()
+                .setDestAccountId(btcServiceAccount)
+                .setAmount("1")
+                .build();
+        handler.handleTransferCommand(transferAsset, System.currentTimeMillis());
+        verify(handler).checkAndStartConsensus(any());
+    }
+}

--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -56,6 +56,14 @@
               },
               {
                 "createRole": {
+                  "roleName": "broadcast",
+                  "permissions": [
+                    "can_set_detail"
+                    ]
+                }
+              },
+              {
+                "createRole": {
                   "roleName": "client",
                   "permissions": [
                     "can_get_my_account",
@@ -398,9 +406,22 @@
               },
               {
                 "createAccount": {
+                  "accountName": "broadcast",
+                  "domainId": "notary",
+                  "publicKey": "e48e003991142b90a3569d6804738c69296f339216166a3e6d20d6380afb25b1"
+                }
+              },
+              {
+                "createAccount": {
                   "accountName": "btc_registration_service",
                   "domainId": "notary",
                   "publicKey": "e48e003991142b90a3569d6804738c69296f339216166a3e6d20d6380afb25b1"
+                }
+              },
+              {
+                "appendRole": {
+                  "accountId": "broadcast@notary",
+                  "roleName": "broadcast"
                 }
               },
               {

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -28,6 +28,7 @@ class BtcConfigHelper(
 
     private val utxoStorageAccountCredential = accountHelper.createTesterAccount("utxo_storage")
     private val txStorageAccountCredential = accountHelper.createTesterAccount("tx_storage")
+    private val broadcastCredential = accountHelper.createTesterAccount("broadcast", "broadcast")
 
     /** Creates config for BTC multisig addresses generation
      * @param initAddresses - number of addresses that will be generated at initial phase
@@ -79,6 +80,7 @@ class BtcConfigHelper(
                 "withdrawal.properties"
             ).get()
         return object : BtcWithdrawalConfig {
+            override val broadcastsCredential = accountHelper.createCredentialRawConfig(broadcastCredential)
             override val utxoStorageAccount = utxoStorageAccountCredential.accountId
             override val txStorageAccount = txStorageAccountCredential.accountId
             override val btcConsensusCredential =


### PR DESCRIPTION
Sometimes it's not safe to broadcast transactions if they have been broadcasted before. We must track broadcasted transactions and ignore any transaction that has been broadcasted already.

**Don't merge until the corresponding changelog script is not merged in 'deploy' repo.**