### PR TITLE
Update bitcoin node

### DIFF
--- a/deploy/bitcoin/regtest/bitcoin.conf
+++ b/deploy/bitcoin/regtest/bitcoin.conf
@@ -1,0 +1,8 @@
+regtest=1
+server=1
+[regtest]
+rpcuser=test
+rpcpassword=test
+rpcport=8332
+rpcbind=0.0.0.0
+rpcallowip=0.0.0.0/0

--- a/deploy/docker-compose.btc.yml
+++ b/deploy/docker-compose.btc.yml
@@ -47,22 +47,19 @@ services:
 
   # bitcoin
   d3-btc-node0:
-    image: kylemanna/bitcoind:dev
+    image: kylemanna/bitcoind:latest
     container_name: d3-btc-node0
+    volumes:
+      - ../deploy/bitcoin/regtest/bitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf
     entrypoint:
       - bitcoind
-      - --rpcuser=test
-      - --rpcpassword=test
-      - --regtest=1
-      - --server=1
-      - --rpcallowip=::/0
-      - --rpcport=8332
+      - -deprecatedrpc=generate
     ports:
       - 8332:8332
       - 18333:18333
       - 18444:18444
     networks:
-        - d3-network
+      - d3-network
 
 networks:
   d3-network:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -31,16 +31,13 @@ services:
 
   # bitcoin
   d3-btc-node0:
-    image: kylemanna/bitcoind:dev
+    image: kylemanna/bitcoind:latest
     container_name: d3-btc-node0
+    volumes:
+      - ../deploy/bitcoin/regtest/bitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf
     entrypoint:
       - bitcoind
-      - --rpcuser=test
-      - --rpcpassword=test
-      - --regtest=1
-      - --server=1
-      - --rpcallowip=::/0
-      - --rpcport=8332
+      - -deprecatedrpc=generate
     networks:
       - d3-network
 


### PR DESCRIPTION
Bitcoind image has been [updated](https://bitcoin.org/en/release/v0.18.0#configuration-option-changes) recently. We must fix our configs to make RPC calls available.