### PR TITLE
Refactor Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,112 +1,60 @@
-
 pipeline {
-  environment {
-    DOCKER_NETWORK = ''
-  }
-  options {
-    skipDefaultCheckout()
-    buildDiscarder(logRotator(numToKeepStr: '20'))
-    timestamps()
-  }
-  agent any
-  stages {
-    stage('Stop same job builds') {
-      agent { label 'master' }
-      steps {
-        script {
-          def scmVars = checkout scm
-          // need this for develop->master PR cases
-          // CHANGE_BRANCH is not defined if this is a branch build
-          try {
-            scmVars.CHANGE_BRANCH_LOCAL = scmVars.CHANGE_BRANCH
-          }
-          catch (MissingPropertyException e) {
-          }
-          if (scmVars.GIT_LOCAL_BRANCH != "develop" && scmVars.CHANGE_BRANCH_LOCAL != "develop") {
-            def builds = load ".jenkinsci/cancel-builds-same-job.groovy"
-            builds.cancelSameJobBuilds()
-          }
-        }
-      }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '20'))
+        timestamps()
     }
-    stage('Tests') {
-      agent { label 'd3-build-agent' }
-      steps {
-        script {
-          def scmVars = checkout scm
-          env.WORKSPACE = pwd()
-
-          DOCKER_NETWORK = "${scmVars.CHANGE_ID}-${scmVars.GIT_COMMIT}-${BUILD_NUMBER}"
-          writeFile file: ".env", text: "SUBNET=${DOCKER_NETWORK}"
-          withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
-            sh "docker login nexus.iroha.tech:19002 -u ${login} -p '${password}'"
-
-            sh "docker-compose -f deploy/docker-compose.yml -f deploy/docker-compose.ci.yml pull"
-            sh(returnStdout: true, script: "docker-compose -f deploy/docker-compose.yml -f deploy/docker-compose.ci.yml up --build -d")
-            sh "docker cp d3-btc-node0-${DOCKER_NETWORK}:/usr/bin/bitcoin-cli deploy/bitcoin/"
-          }
-
-          iC = docker.image("gradle:4.10.2-jdk8-slim")
-          iC.inside("--network='d3-${DOCKER_NETWORK}' -e JVM_OPTS='-Xmx3200m' -e TERM='dumb' -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp") {
-            sh "ln -s deploy/bitcoin/bitcoin-cli /usr/bin/bitcoin-cli"
-            sh "gradle dependencies"
-            sh "gradle test --info"
-            sh "gradle shadowJar"
-            sh "gradle dockerfileCreate"
-            sh "gradle compileIntegrationTestKotlin --info"
-            sh "gradle integrationTest --info"
-            sh "gradle d3TestReport"
-          }
-          publishHTML (target: [
-                        allowMissing: false,
-                        alwaysLinkToLastBuild: false,
-                        keepAll: true,
-                        reportDir: 'build/reports',
-                        reportFiles: 'd3-test-report.html',
-                        reportName: "D3 test report"
-                      ])
+    agent {
+        docker {
+            label 'd3-build-agent'
+            image 'openjdk:8-jdk-alpine'
+            args '-v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp'
         }
-      }
-      post {
+    }
+    stages {
+        stage('Build') {
+            steps {
+                script {
+                    sh "./gradlew build --info"
+                }
+            }
+        }
+        stage('Test') {
+            steps {
+                script {
+                    sh "./gradlew test --info"
+                }
+            }
+        }
+        stage('Build artifacts') {
+            steps {
+                script {
+                    if (env.BRANCH_NAME ==~ /(master|develop)/ || env.TAG_NAME) {
+                        DOCKER_TAGS = ['master': 'latest', 'develop': 'develop']
+                        withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
+                          env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19002"
+                          env.DOCKER_REGISTRY_USERNAME = "${login}"
+                          env.DOCKER_REGISTRY_PASSWORD = "${password}"
+                          env.TAG = env.TAG_NAME ? env.TAG_NAME : DOCKER_TAGS[env.BRANCH_NAME]
+                          sh "./gradlew dockerPush"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
         cleanup {
-          sh "mkdir -p build-logs"
-          sh """#!/bin/bash
-            while read -r LINE; do \
-              docker logs \$(echo \$LINE | cut -d ' ' -f1) | gzip -6 > build-logs/\$(echo \$LINE | cut -d ' ' -f2).log.gz; \
-            done < <(docker ps --filter "network=d3-${DOCKER_NETWORK}" --format "{{.ID}} {{.Names}}")
-          """
-          
-          sh "tar -zcvf build-logs/notaryBtcIntegrationTest.gz -C notary-btc-integration-test/build/reports/tests integrationTest || true"
-          sh "tar -zcvf build-logs/dokka.gz -C build/reports dokka || true"
-          archiveArtifacts artifacts: 'build-logs/*.gz'
-          sh "docker-compose -f deploy/docker-compose.yml -f deploy/docker-compose.ci.yml down"
-          cleanWs()
+            cleanWs()
         }
-      }
-    }
-
-    stage('Build and push docker images') {
-      agent { label 'd3-build-agent' }
-      steps {
-        script {
-          def scmVars = checkout scm
-          if (env.BRANCH_NAME ==~ /(master|develop|reserved)/ || env.TAG_NAME) {
-                withCredentials([usernamePassword(credentialsId: 'nexus-d3-docker', usernameVariable: 'login', passwordVariable: 'password')]) {
-                  TAG = env.TAG_NAME ? env.TAG_NAME : env.BRANCH_NAME
-                  iC = docker.image("gradle:4.10.2-jdk8-slim")
-                  iC.inside(" -e JVM_OPTS='-Xmx3200m' -e TERM='dumb'"+
-                  " -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/tmp"+
-                  " -e DOCKER_REGISTRY_URL='https://nexus.iroha.tech:19002'"+
-                  " -e DOCKER_REGISTRY_USERNAME='${login}'"+
-                  " -e DOCKER_REGISTRY_PASSWORD='${password}'"+
-                  " -e TAG='${TAG}'") {
-                    sh "gradle shadowJar"
-                    sh "gradle dockerPush"
-                  }
-                 }
-              }
+        always {
+          publishHTML (target: [
+            allowMissing: false,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'build/reports',
+            reportFiles: 'd3-test-report.html',
+            reportName: "D3 test report"
+          ])
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

This PR introduces changes in Jenkinsfile to make it consistent across different projects in D3Ledger organization. Jenkinsfile is now a kind of a contract that should be met (status checks must pass) prior merging it. There are some points that need attention:
- [X] Get rid of entire `cleanup` stage that archives build logs no one really look into
- [ ] Running `gradle test` should be identical to running `gradle test, gradle compileIntegrationTestKotlin, gradle integrationTest, gradle d3TestReport` commands sequence.
- [ ] Running integration tests task should be the subset of `gradle test` task (a separate task for unit tests?)
- [ ] Integrate `testcontainers` to make `gradle test` to spin up all the necessary dependencies prior running integration tests and shutting them down gracefully afterwards.

You can freely add more commits into this PR to make it pass the CI.
