### PR TITLE
Separating notary account

### DIFF
--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcDepositConfig.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/config/BtcDepositConfig.kt
@@ -5,9 +5,7 @@
 
 package com.d3.btc.deposit.config
 
-import com.d3.btc.config.BitcoinConfig
 import com.d3.commons.config.IrohaConfig
-import com.d3.commons.config.IrohaCredentialConfig
 import com.d3.commons.config.IrohaCredentialRawConfig
 
 const val BTC_DEPOSIT_SERVICE_NAME = "btc-deposit"
@@ -17,7 +15,9 @@ interface BtcDepositConfig {
 
     val iroha: IrohaConfig
 
-    val notaryCredential: IrohaCredentialRawConfig
+    val depositServiceCredential: IrohaCredentialRawConfig
+
+    val notaryAccount: String
 
     val registrationAccount: String
 

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/expansion/DepositServiceExpansion.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/expansion/DepositServiceExpansion.kt
@@ -17,15 +17,15 @@ import org.springframework.stereotype.Component
 class DepositServiceExpansion(
     private val irohaAPI: IrohaAPI,
     private val serviceExpansion: ServiceExpansion,
-    @Qualifier("notaryCredential")
-    private val notaryCredential: IrohaCredential
+    @Qualifier("depositServiceCredential")
+    private val depositServiceCredential: IrohaCredential
 ) {
 
     fun expand(block: BlockOuterClass.Block) {
         serviceExpansion.expand(block) { expansionsDetails, _, triggerTime ->
             ExpansionUtils.addSignatureExpansionLogic(
                 irohaAPI,
-                notaryCredential,
+                depositServiceCredential,
                 expansionsDetails,
                 triggerTime
             )

--- a/btc-deposit/src/main/resources/deposit_local.properties
+++ b/btc-deposit/src/main/resources/deposit_local.properties
@@ -3,10 +3,11 @@ btc-deposit.registrationAccount=btc_registration_service@notary
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/regtest/transfers.d3.wallet
 btc-deposit.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-deposit.changeAddressesStorageAccount=btc_change_addresses@notary
-# --------- Credentials ------- 
-btc-deposit.notaryCredential.accountId=notary@notary
-btc-deposit.notaryCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
-btc-deposit.notaryCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
+btc-deposit.notaryAccount=notary@notary
+# --------- Credentials -------
+btc-deposit.depositServiceCredential.accountId=deposit_service@notary
+btc-deposit.depositServiceCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
+btc-deposit.depositServiceCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
 # --------- Iroha ---------
 # Iroha peer hostname
 btc-deposit.iroha.hostname=d3-iroha

--- a/btc-deposit/src/main/resources/deposit_mainnet.properties
+++ b/btc-deposit/src/main/resources/deposit_mainnet.properties
@@ -3,10 +3,11 @@ btc-deposit.registrationAccount=btc_registration_service@notary
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/mainnet/transfers.d3.wallet
 btc-deposit.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-deposit.changeAddressesStorageAccount=btc_change_addresses@notary
+btc-deposit.notaryAccount=notary@notary
 # --------- Credentials -------
-btc-deposit.notaryCredential.accountId=notary@notary
-btc-deposit.notaryCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
-btc-deposit.notaryCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
+btc-deposit.depositServiceCredential.accountId=deposit_service@notary
+btc-deposit.depositServiceCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
+btc-deposit.depositServiceCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
 # --------- Iroha ---------
 # Iroha peer hostname
 btc-deposit.iroha.hostname=d3-iroha

--- a/btc-deposit/src/main/resources/deposit_testnet.properties
+++ b/btc-deposit/src/main/resources/deposit_testnet.properties
@@ -3,10 +3,11 @@ btc-deposit.registrationAccount=btc_registration_service@notary
 btc-deposit.btcTransferWalletPath=deploy/bitcoin/testnet/transfers.d3.wallet
 btc-deposit.mstRegistrationAccount=mst_btc_registration_service@notary
 btc-deposit.changeAddressesStorageAccount=btc_change_addresses@notary
+btc-deposit.notaryAccount=notary@notary
 # --------- Credentials -------
-btc-deposit.notaryCredential.accountId=notary@notary
-btc-deposit.notaryCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
-btc-deposit.notaryCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
+btc-deposit.depositServiceCredential.accountId=deposit_service@notary
+btc-deposit.depositServiceCredential.pubkey=825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1
+btc-deposit.depositServiceCredential.privkey=d7a82f32288ab60d12dc8c1d15110b1712ae99a8a9529d56944deb3267bb219e
 # --------- Iroha ---------
 # Iroha peer hostname
 btc-deposit.iroha.hostname=d3-iroha

--- a/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
+++ b/btc-dw-bridge/src/main/kotlin/com/d3/btc/dwbridge/config/BtcDWBridgeAppConfiguration.kt
@@ -60,9 +60,9 @@ class BtcDWBridgeAppConfiguration {
         withdrawalConfig.withdrawalCredential.pubkey,
         withdrawalConfig.withdrawalCredential.privkey
     )
-    private val notaryKeypair = Utils.parseHexKeypair(
-        depositConfig.notaryCredential.pubkey,
-        depositConfig.notaryCredential.privkey
+    private val depositServiceKeyPair = Utils.parseHexKeypair(
+        depositConfig.depositServiceCredential.pubkey,
+        depositConfig.depositServiceCredential.privkey
     )
 
     private val signatureCollectorKeypair = Utils.parseHexKeypair(
@@ -86,11 +86,11 @@ class BtcDWBridgeAppConfiguration {
             )
         )
 
-    private val notaryCredential =
-        IrohaCredential(depositConfig.notaryCredential.accountId, notaryKeypair)
+    private val depositServiceCredential =
+        IrohaCredential(depositConfig.depositServiceCredential.accountId, depositServiceKeyPair)
 
     @Bean
-    fun notaryCredential() = notaryCredential
+    fun depositServiceCredential() = depositServiceCredential
 
     @Bean
     fun consensusIrohaCredential() = btcConsensusCredential
@@ -115,8 +115,8 @@ class BtcDWBridgeAppConfiguration {
     @Bean
     fun notary() =
         NotaryImpl(
-            MultiSigIrohaConsumer(notaryCredential, irohaAPI()),
-            notaryCredential,
+            MultiSigIrohaConsumer(depositServiceCredential, irohaAPI()),
+            depositServiceCredential,
             btcEventsObservable()
         )
 
@@ -159,11 +159,11 @@ class BtcDWBridgeAppConfiguration {
         return BtcRegisteredAddressesProvider(
             IrohaQueryHelperImpl(
                 irohaAPI(),
-                depositConfig.notaryCredential.accountId,
-                notaryKeypair
+                depositConfig.depositServiceCredential.accountId,
+                depositServiceKeyPair
             ),
             depositConfig.registrationAccount,
-            depositConfig.notaryCredential.accountId
+            depositConfig.notaryAccount
         )
     }
 
@@ -204,7 +204,7 @@ class BtcDWBridgeAppConfiguration {
     fun depositIrohaChainListener() = IrohaChainListener(
         dwBridgeConfig.iroha.hostname,
         dwBridgeConfig.iroha.port,
-        notaryCredential
+        depositServiceCredential
     )
 
     @Bean

--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -16,6 +16,28 @@
               },
               {
                 "createRole": {
+                  "roleName": "deposit",
+                  "permissions": [
+                    "can_get_all_acc_ast",
+                    "can_get_all_accounts",
+                    "can_get_all_acc_detail",
+                    "can_create_asset",
+                    "can_add_asset_qty",
+                    "can_transfer",
+                    "can_set_detail",
+                    "can_get_all_txs",
+                    "can_get_blocks",
+                    "can_read_assets",
+                    "can_add_signatory",
+                    "can_set_quorum",
+                    "can_grant_can_set_my_quorum",
+                    "can_grant_can_add_my_signatory",
+                    "can_grant_can_transfer_my_assets"
+                  ]
+                }
+              },
+              {
+                "createRole": {
                   "roleName": "notary",
                   "permissions": [
                     "can_get_all_acc_ast",
@@ -371,8 +393,7 @@
                   "accountId": "btc_consensus_collector@notary",
                   "roleName": "consensus_collector"
                 }
-              },
-              {
+              },{
                 "createAccount": {
                   "accountName": "notary",
                   "domainId": "notary",
@@ -383,6 +404,19 @@
                 "appendRole": {
                   "accountId": "notary@notary",
                   "roleName": "notary"
+                }
+              },
+              {
+                "createAccount": {
+                  "accountName": "deposit_service",
+                  "domainId": "notary",
+                  "publicKey": "825fd700dba3b294dd65029b2ec1f21b5bf464e6f795c487962cb598780ab0d1"
+                }
+              },
+              {
+                "appendRole": {
+                  "accountId": "deposit_service@notary",
+                  "roleName": "deposit"
                 }
               },
               {

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcDepositFailResistanceIntegrationTest.kt
@@ -55,7 +55,7 @@ class BtcDepositFailResistanceIntegrationTest {
      */
     @Test
     fun testDeposit() {
-        val walletFile = File(environment.notaryConfig.btcTransferWalletPath)
+        val walletFile = File(environment.depositConfig.btcTransferWalletPath)
         val transfersWallet = Wallet.loadFromFile(walletFile)
         val initUTXOCount = transfersWallet.unspents.size
         val randomName = String.getRandomString(9)

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiNotaryIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcMultiNotaryIntegrationTest.kt
@@ -33,16 +33,16 @@ class BtcMultiNotaryIntegrationTest {
         registrationServiceEnvironment.registrationInitialization.init()
         var peerCount = 0
         //Create configs for multiple notary services
-        integrationHelper.accountHelper.notaryAccounts
-            .forEach { notaryAccount ->
+        integrationHelper.accountHelper.makeAccountMst(integrationHelper.configHelper.depositAccountCredential)
+            .forEach { depositAccount ->
                 val testName = "multi_notary_${peerCount++}"
                 val notaryConfig =
-                    integrationHelper.configHelper.createBtcDepositConfig(testName, notaryAccount)
+                    integrationHelper.configHelper.createBtcDepositConfig(testName, depositAccount)
                 val notaryEnvironment =
                     BtcNotaryTestEnvironment(
                         integrationHelper = integrationHelper,
-                        notaryConfig = notaryConfig,
-                        notaryCredential = notaryAccount,
+                        depositConfig = notaryConfig,
+                        depositServiceCredential = depositAccount,
                         testName = testName
                     )
                 environments.add(notaryEnvironment)
@@ -85,7 +85,7 @@ class BtcMultiNotaryIntegrationTest {
         assertEquals(200, res.statusCode)
         val btcAddress =
             integrationHelper.registerBtcAddress(
-                environments.first().notaryConfig.btcTransferWalletPath,
+                environments.first().depositConfig.btcTransferWalletPath,
                 randomName,
                 CLIENT_DOMAIN
             )

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcNotaryIntegrationTest.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/BtcNotaryIntegrationTest.kt
@@ -57,7 +57,7 @@ class BtcNotaryIntegrationTest {
     @Test
     fun testDeposit() {
         val initUTXOCount =
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         val randomName = String.getRandomString(9)
         val testClient = "$randomName@$CLIENT_DOMAIN"
         val res = registrationServiceEnvironment.register(randomName)
@@ -83,7 +83,7 @@ class BtcNotaryIntegrationTest {
         assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
         assertEquals(
             initUTXOCount + 1,
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         )
     }
 
@@ -96,7 +96,7 @@ class BtcNotaryIntegrationTest {
     @Test
     fun testMultipleDeposit() {
         val initUTXOCount =
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         val totalDeposits = 3
         val randomName = String.getRandomString(9)
         val testClient = "$randomName@$CLIENT_DOMAIN"
@@ -125,7 +125,7 @@ class BtcNotaryIntegrationTest {
         assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
         assertEquals(
             initUTXOCount + totalDeposits,
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         )
     }
 
@@ -140,7 +140,7 @@ class BtcNotaryIntegrationTest {
     @Test
     fun testMultipleDepositMultiThreaded() {
         val initUTXOCount =
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         val totalDeposits = 5
         val randomName = String.getRandomString(9)
         val testClient = "$randomName@$CLIENT_DOMAIN"
@@ -178,7 +178,7 @@ class BtcNotaryIntegrationTest {
         assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
         assertEquals(
             initUTXOCount + totalDeposits,
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         )
     }
 
@@ -191,7 +191,7 @@ class BtcNotaryIntegrationTest {
     @Test
     fun testDepositNotConfirmed() {
         val initUTXOCount =
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         val randomName = String.getRandomString(9)
         val testClient = "$randomName@$CLIENT_DOMAIN"
         val res = registrationServiceEnvironment.register(randomName)
@@ -218,7 +218,7 @@ class BtcNotaryIntegrationTest {
         assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
         assertEquals(
             initUTXOCount + 1,
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         )
     }
 
@@ -232,7 +232,7 @@ class BtcNotaryIntegrationTest {
     @Test
     fun testDepositConfirmation() {
         val initUTXOCount =
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         val randomName = String.getRandomString(9)
         val testClient = "$randomName@$CLIENT_DOMAIN"
         val res = registrationServiceEnvironment.register(randomName)
@@ -263,7 +263,7 @@ class BtcNotaryIntegrationTest {
         assertTrue(environment.btcNotaryInitialization.isWatchedAddress(btcAddress))
         assertEquals(
             initUTXOCount + 1,
-            Wallet.loadFromFile(File(environment.notaryConfig.btcTransferWalletPath)).unspents.size
+            Wallet.loadFromFile(File(environment.depositConfig.btcTransferWalletPath)).unspents.size
         )
     }
 }

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcNotaryTestEnvironment.kt
@@ -43,28 +43,28 @@ import java.io.File
 class BtcNotaryTestEnvironment(
     private val integrationHelper: BtcIntegrationHelperUtil,
     testName: String = "",
-    val notaryConfig: BtcDepositConfig = integrationHelper.configHelper.createBtcDepositConfig(
+    val depositConfig: BtcDepositConfig = integrationHelper.configHelper.createBtcDepositConfig(
         testName
     ),
     val bitcoinConfig: BitcoinConfig = integrationHelper.configHelper.createBitcoinConfig(testName),
-    private val notaryCredential: IrohaCredential = IrohaCredential(
-        notaryConfig.notaryCredential.accountId,
+    private val depositServiceCredential: IrohaCredential = IrohaCredential(
+        depositConfig.depositServiceCredential.accountId,
         Utils.parseHexKeypair(
-            notaryConfig.notaryCredential.pubkey,
-            notaryConfig.notaryCredential.privkey
+            depositConfig.depositServiceCredential.pubkey,
+            depositConfig.depositServiceCredential.privkey
         )
     )
 ) : Closeable {
 
-    private val irohaAPI = IrohaAPI(notaryConfig.iroha.hostname, notaryConfig.iroha.port)
+    private val irohaAPI = IrohaAPI(depositConfig.iroha.hostname, depositConfig.iroha.port)
 
     private val queryHelper =
-        IrohaQueryHelperImpl(irohaAPI, notaryCredential.accountId, notaryCredential.keyPair)
+        IrohaQueryHelperImpl(irohaAPI, depositServiceCredential.accountId, depositServiceCredential.keyPair)
 
     private val btcRegisteredAddressesProvider = BtcRegisteredAddressesProvider(
         queryHelper,
-        notaryConfig.registrationAccount,
-        notaryConfig.notaryCredential.accountId
+        depositConfig.registrationAccount,
+        depositConfig.notaryAccount
     )
 
     val btcAddressGenerationConfig =
@@ -73,9 +73,9 @@ class BtcNotaryTestEnvironment(
     private val btcNetworkConfigProvider = BtcRegTestConfigProvider()
 
     val irohaChainListener = IrohaChainListener(
-        notaryConfig.iroha.hostname,
-        notaryConfig.iroha.port,
-        notaryCredential
+        depositConfig.iroha.hostname,
+        depositConfig.iroha.port,
+        depositServiceCredential
     )
 
     private val newBtcClientRegistrationListener =
@@ -85,7 +85,7 @@ class BtcNotaryTestEnvironment(
         )
 
     private val transferWallet by lazy {
-        loadAutoSaveWallet(notaryConfig.btcTransferWalletPath)
+        loadAutoSaveWallet(depositConfig.btcTransferWalletPath)
     }
 
     private val peerGroup by lazy {
@@ -94,8 +94,8 @@ class BtcNotaryTestEnvironment(
 
     private val btcChangeAddressProvider = BtcChangeAddressProvider(
         queryHelper,
-        notaryConfig.mstRegistrationAccount,
-        notaryConfig.changeAddressesStorageAccount
+        depositConfig.mstRegistrationAccount,
+        depositConfig.changeAddressesStorageAccount
     )
 
     private val walletInitializer by lazy {
@@ -121,8 +121,8 @@ class BtcNotaryTestEnvironment(
         btcEventsSource
 
     private val notary = NotaryImpl(
-        MultiSigIrohaConsumer(notaryCredential, irohaAPI),
-        notaryCredential,
+        MultiSigIrohaConsumer(depositServiceCredential, irohaAPI),
+        depositServiceCredential,
         btcEventsObservable
     )
 
@@ -140,7 +140,7 @@ class BtcNotaryTestEnvironment(
         BtcNotaryInitialization(
             peerGroup,
             transferWallet,
-            notaryConfig,
+            depositConfig,
             bitcoinConfig,
             notary,
             btcRegisteredAddressesProvider,
@@ -156,7 +156,7 @@ class BtcNotaryTestEnvironment(
                     integrationHelper.accountHelper.expansionTriggerAccount.accountId,
                     ChangelogInterface.superuserAccountId,
                     irohaAPI
-                ), notaryCredential
+                ), depositServiceCredential
             )
         )
     }

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -11,6 +11,7 @@ import com.d3.btc.dwbridge.config.BtcDWBridgeConfig
 import com.d3.btc.generation.config.BtcAddressGenerationConfig
 import com.d3.btc.registration.config.BtcRegistrationConfig
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
+import com.d3.commons.config.IrohaCredentialRawConfig
 import com.d3.commons.config.loadLocalConfigs
 import com.d3.commons.model.IrohaCredential
 import org.bitcoinj.params.RegTestParams
@@ -26,6 +27,7 @@ class BtcConfigHelper(
     private val accountHelper: IrohaAccountHelper
 ) : IrohaConfigHelper() {
 
+    val depositAccountCredential = accountHelper.createTesterAccount("deposit", "deposit")
     private val utxoStorageAccountCredential = accountHelper.createTesterAccount("utxo_storage")
     private val txStorageAccountCredential = accountHelper.createTesterAccount("tx_storage")
     private val broadcastCredential = accountHelper.createTesterAccount("broadcast", "broadcast")
@@ -132,14 +134,14 @@ class BtcConfigHelper(
             "deposit.properties"
         ).get()
         return object : BtcDepositConfig {
+            override val notaryAccount = notaryIrohaCredential.accountId
+            override val depositServiceCredential = accountHelper.createCredentialRawConfig(depositAccountCredential)
             override val mstRegistrationAccount = accountHelper.mstRegistrationAccount.accountId
             override val changeAddressesStorageAccount =
                 accountHelper.changeAddressesStorageAccount.accountId
             override val btcTransferWalletPath = createWalletFile("transfers.$testName")
             override val registrationAccount = accountHelper.registrationAccount.accountId
             override val iroha = createIrohaConfig()
-            override val notaryCredential =
-                accountHelper.createCredentialRawConfig(notaryIrohaCredential)
         }
     }
 


### PR DESCRIPTION
The `notary@notary` account is slightly overused. We must provide another account to handle deposits.