### PR TITLE
Fix invalid address rollback

### DIFF
--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
@@ -166,12 +166,11 @@ class BtcWithdrawalInitialization(
         transaction.payload.reducedPayload.commandsList.forEach { command ->
             if (command.hasTransferAsset()) {
                 val transferCommand = command.transferAsset
-                if (isValidBtcAddress(transferCommand.description)) {
-                    // If description is a valid BTC address, then it's a withdrawal command
-                    withdrawalCommand = command
-                } else if (transferCommand.description == FEE_DESCRIPTION) {
+                if (transferCommand.description == FEE_DESCRIPTION) {
                     // If description equals to 'withdrawal fee', then it's a fee command
                     feeCommand = command
+                } else {
+                    withdrawalCommand = command
                 }
             }
         }


### PR DESCRIPTION
Withdrawal transfers with invalid BTC addresses were ignored. If we ignore these transfers, they will not be rolled back then. We must "let them in" to rollback it in the future.