### PR TITLE
Refactor peer list provider in the address generation service

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationAppConfiguration.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationAppConfiguration.kt
@@ -17,8 +17,6 @@ import com.d3.commons.config.loadLocalConfigs
 import com.d3.commons.config.loadRawLocalConfigs
 import com.d3.commons.expansion.ServiceExpansion
 import com.d3.commons.model.IrohaCredential
-import com.d3.commons.provider.NotaryPeerListProvider
-import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.sidechain.iroha.ReliableIrohaChainListener
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
 import com.d3.commons.sidechain.iroha.consumer.MultiSigIrohaConsumer
@@ -116,14 +114,6 @@ class BtcAddressGenerationAppConfiguration {
         return Wallet.loadFromFile(File(walletPath))!!
     }
 
-    @Bean
-    fun notaryPeerListProvider(): NotaryPeerListProvider {
-        return NotaryPeerListProviderImpl(
-            registrationQueryHelper(),
-            btcAddressGenerationConfig.notaryListStorageAccount,
-            btcAddressGenerationConfig.notaryListSetterAccount
-        )
-    }
 
     @Bean
     fun sessionConsumer() = IrohaConsumerImpl(registrationCredential, generationIrohaAPI())

--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationConfig.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/config/BtcAddressGenerationConfig.kt
@@ -23,21 +23,14 @@ interface BtcAddressGenerationConfig {
     //Path to BTC wallet file
     val btcKeysWalletPath: String
 
-    //TODO the only purpose of this account is creating PeerListProvider. This account must be removed from config.
     //Account that is used to register BTC addresses
     val registrationAccount: IrohaCredentialRawConfig
 
     //Account that is used to register BTC addresses in MST fashion
     val mstRegistrationAccount: IrohaCredentialRawConfig
 
-    //Account that stores all registered notaries
-    val notaryListStorageAccount: String
-
     //Account that stores change addresses
     val changeAddressesStorageAccount: String
-
-    //Account that sets registered notaries
-    val notaryListSetterAccount: String
 
     //Port of health check service
     val healthCheckPort: Int

--- a/btc-address-generation/src/main/resources/address_generation_local.properties
+++ b/btc-address-generation/src/main/resources/address_generation_local.properties
@@ -1,9 +1,7 @@
 # ========= Bitcoin PK generation =========
 btc-address-generation.pubKeyTriggerAccount=gen_btc_pk_trigger@notary
 btc-address-generation.notaryAccount=notary@notary
-btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
-btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
 btc-address-generation.threshold=2
 btc-address-generation.expansionTriggerAccount=expansion_trigger@notary

--- a/btc-address-generation/src/main/resources/address_generation_mainnet.properties
+++ b/btc-address-generation/src/main/resources/address_generation_mainnet.properties
@@ -1,9 +1,7 @@
 # ========= Bitcoin PK generation =========
 btc-address-generation.pubKeyTriggerAccount=gen_btc_pk_trigger@notary
 btc-address-generation.notaryAccount=notary@notary
-btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
-btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
 btc-address-generation.threshold=2
 btc-address-generation.expansionTriggerAccount=expansion_trigger@notary

--- a/btc-address-generation/src/main/resources/address_generation_testnet.properties
+++ b/btc-address-generation/src/main/resources/address_generation_testnet.properties
@@ -1,9 +1,7 @@
 # ========= Bitcoin PK generation =========
 btc-address-generation.pubKeyTriggerAccount=gen_btc_pk_trigger@notary
 btc-address-generation.notaryAccount=notary@notary
-btc-address-generation.notaryListStorageAccount=notaries@notary
 btc-address-generation.healthCheckPort=7071
-btc-address-generation.notaryListSetterAccount=notary@notary
 btc-address-generation.changeAddressesStorageAccount=btc_change_addresses@notary
 btc-address-generation.threshold=2
 btc-address-generation.expansionTriggerAccount=expansion_trigger@notary

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.21'
     ext.ktor_version = '1.0.0'
-    ext.notary_version = 'deb14bdf00b31133aa843c1098df7eb99be397a4'
+    ext.notary_version = '22b63cb311f624312581f4064940324d2c136a59'
     repositories {
         mavenCentral()
         jcenter()

--- a/deploy/iroha/genesis.block
+++ b/deploy/iroha/genesis.block
@@ -50,7 +50,8 @@
                     "can_get_blocks",
                     "can_set_quorum",
                     "can_grant_can_set_my_quorum",
-                    "can_grant_can_add_my_signatory"
+                    "can_grant_can_add_my_signatory",
+                    "can_get_peers"
                   ]
                 }
               },

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
@@ -27,7 +27,6 @@ import com.d3.commons.config.RMQConfig
 import com.d3.commons.config.loadRawLocalConfigs
 import com.d3.commons.expansion.ServiceExpansion
 import com.d3.commons.model.IrohaCredential
-import com.d3.commons.provider.NotaryPeerListProviderImpl
 import com.d3.commons.provider.TriggerProvider
 import com.d3.commons.sidechain.iroha.ReliableIrohaChainListener
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumerImpl
@@ -126,14 +125,9 @@ class BtcAddressGenerationTestEnvironment(
     )
 
     private fun btcPublicKeyProvider(): BtcPublicKeyProvider {
-        val notaryPeerListProvider = NotaryPeerListProviderImpl(
-            registrationQueryHelper,
-            btcGenerationConfig.notaryListStorageAccount,
-            btcGenerationConfig.notaryListSetterAccount
-        )
         return BtcPublicKeyProvider(
+            registrationQueryHelper,
             keysWallet,
-            notaryPeerListProvider,
             btcGenerationConfig.notaryAccount,
             btcGenerationConfig.changeAddressesStorageAccount,
             multiSigConsumer,

--- a/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
+++ b/notary-btc-integration-test/src/main/kotlin/integration/helper/BtcConfigHelper.kt
@@ -55,8 +55,6 @@ class BtcConfigHelper(
             override val changeAddressesStorageAccount =
                 accountHelper.changeAddressesStorageAccount.accountId
             override val healthCheckPort = btcAddressGenConfig.healthCheckPort
-            override val notaryListStorageAccount = accountHelper.notaryListStorageAccount.accountId
-            override val notaryListSetterAccount = accountHelper.notaryAccount.accountId
             override val mstRegistrationAccount =
                 accountHelper.createCredentialRawConfig(accountHelper.mstRegistrationAccount)
             override val pubKeyTriggerAccount = btcAddressGenConfig.pubKeyTriggerAccount


### PR DESCRIPTION
There is no need to use `NotaryPeerListProvider` because all information about peers may be taken using brand new 'get peers' API call.