### PR TITLE
Transaction creator check

### DIFF
--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/BtcAddressGenerationTriggerHandler.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/BtcAddressGenerationTriggerHandler.kt
@@ -6,6 +6,7 @@
 package com.d3.btc.generation.handler
 
 import com.d3.btc.generation.config.BtcAddressGenerationConfig
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.provider.generation.BtcPublicKeyProvider
 import com.d3.btc.wallet.safeSave
@@ -27,9 +28,9 @@ class BtcAddressGenerationTriggerHandler(
     private val btcPublicKeyProvider: BtcPublicKeyProvider
 ) : SetAccountDetailHandler() {
 
-    override fun handle(command: Commands.SetAccountDetail) {
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
         //add new public key to session account, if trigger account was changed
-        val sessionAccountName = command.key
+        val sessionAccountName = setAccountDetailEvent.command.key
         onGenerateKey(sessionAccountName).fold(
             { pubKey -> logger.info { "New public key $pubKey for BTC multisignature address was created" } },
             { ex ->
@@ -45,8 +46,9 @@ class BtcAddressGenerationTriggerHandler(
         return btcPublicKeyProvider.createKey(sessionAccountName) { keysWallet.safeSave(btcAddressGenerationConfig.btcKeysWalletPath) }
     }
 
-    override fun filter(command: Commands.SetAccountDetail) =
-        command.accountId == btcAddressGenerationConfig.pubKeyTriggerAccount
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId == btcAddressGenerationConfig.pubKeyTriggerAccount
+                && setAccountDetailEvent.creator == btcAddressGenerationConfig.registrationAccount.accountId
 
     companion object : KLogging()
 }

--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/BtcAddressRegisteredHandler.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/BtcAddressRegisteredHandler.kt
@@ -7,10 +7,10 @@ package com.d3.btc.generation.handler
 
 import com.d3.btc.generation.config.BtcAddressGenerationConfig
 import com.d3.btc.generation.trigger.AddressGenerationTrigger
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.provider.account.BTC_CURRENCY_NAME_KEY
 import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
-import iroha.protocol.Commands
 import mu.KLogging
 import org.springframework.stereotype.Component
 
@@ -23,7 +23,7 @@ class BtcAddressRegisteredHandler(
     private val btcAddressGenerationConfig: BtcAddressGenerationConfig
 ) : SetAccountDetailHandler() {
 
-    override fun handle(command: Commands.SetAccountDetail) {
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
         logger.info("BTC address has been registered. Try to generate more addresses.")
         addressGenerationTrigger.startFreeAddressGenerationIfNeeded(
             btcAddressGenerationConfig.threshold,
@@ -35,11 +35,13 @@ class BtcAddressRegisteredHandler(
 
     /**
      * Checks if BTC address was registered
-     * @param command - command to check
-     * @return true if BTC address was registered in a given [command]
+     * @param setAccountDetailEvent - event to check
+     * @return true if BTC address was registered in a given event
      */
-    override fun filter(command: Commands.SetAccountDetail) = command.accountId.endsWith("@$CLIENT_DOMAIN")
-            && command.key == BTC_CURRENCY_NAME_KEY
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId.endsWith("@$CLIENT_DOMAIN")
+                && setAccountDetailEvent.command.key == BTC_CURRENCY_NAME_KEY
+                && setAccountDetailEvent.creator == btcAddressGenerationConfig.registrationAccount.accountId
 
     companion object : KLogging()
 }

--- a/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/NewKeyHandler.kt
+++ b/btc-address-generation/src/main/kotlin/com/d3/btc/generation/handler/NewKeyHandler.kt
@@ -6,6 +6,7 @@
 package com.d3.btc.generation.handler
 
 import com.d3.btc.generation.config.BtcAddressGenerationConfig
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.model.BtcAddressType
 import com.d3.btc.model.getAddressTypeByAccountId
@@ -37,8 +38,8 @@ class NewKeyHandler(
     private val btcPublicKeyProvider: BtcPublicKeyProvider
 ) : SetAccountDetailHandler() {
 
-    override fun handle(command: Commands.SetAccountDetail) {
-        val accountId = command.accountId
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val accountId = setAccountDetailEvent.command.accountId
         //create multisignature address, if we have enough keys in session account
         onGenerateMultiSigAddress(
             accountId,
@@ -85,12 +86,14 @@ class NewKeyHandler(
 
     /**
      * Checks if new key was added
-     * @param command - command to check
-     * @return true if given [command] is a 'new key' event command
+     * @param setAccountDetailEvent - event to check
+     * @return true if given event is a 'new key' event
      */
-    override fun filter(command: Commands.SetAccountDetail) = command.accountId.endsWith("btcSession")
-            && command.key != ADDRESS_GENERATION_TIME_KEY
-            && command.key != ADDRESS_GENERATION_NODE_ID_KEY
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId.endsWith("btcSession")
+                && setAccountDetailEvent.command.key != ADDRESS_GENERATION_TIME_KEY
+                && setAccountDetailEvent.command.key != ADDRESS_GENERATION_NODE_ID_KEY
+                && setAccountDetailEvent.creator == btcAddressGenerationConfig.registrationAccount.accountId
 
 
     companion object : KLogging()

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/NewBtcChangeAddressDepositHandler.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/handler/NewBtcChangeAddressDepositHandler.kt
@@ -1,9 +1,9 @@
 package com.d3.btc.deposit.handler
 
 import com.d3.btc.deposit.config.BtcDepositConfig
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.storage.BtcAddressStorage
-import iroha.protocol.Commands
 import org.springframework.stereotype.Component
 
 /**
@@ -15,15 +15,15 @@ class NewBtcChangeAddressDepositHandler(
     private val btcDepositConfig: BtcDepositConfig
 ) : SetAccountDetailHandler() {
 
-    override fun handle(command: Commands.SetAccountDetail) {
-        val address = command.key
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val address = setAccountDetailEvent.command.key
         btcAddressStorage.addChangeAddress(address)
     }
 
     /**
-     * Checks if command is a 'new change address' event
+     * Checks if event is a 'new change address' event
      */
-    override fun filter(command: Commands.SetAccountDetail) =
-        command.accountId == btcDepositConfig.changeAddressesStorageAccount
-
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId == btcDepositConfig.changeAddressesStorageAccount
+                && setAccountDetailEvent.creator == btcDepositConfig.mstRegistrationAccount
 }

--- a/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
+++ b/btc-deposit/src/main/kotlin/com/d3/btc/deposit/init/BtcNotaryInitialization.kt
@@ -11,6 +11,7 @@ import com.d3.btc.deposit.config.BtcDepositConfig
 import com.d3.btc.deposit.expansion.DepositServiceExpansion
 import com.d3.btc.deposit.listener.BitcoinBlockChainDepositListener
 import com.d3.btc.deposit.service.BtcWalletListenerRestartService
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.storage.BtcAddressStorage
 import com.d3.btc.healthcheck.HealthyService
@@ -23,6 +24,7 @@ import com.d3.chainadapter.client.ReliableIrohaChainListener
 import com.d3.commons.notary.NotaryImpl
 import com.d3.commons.sidechain.SideChainEvent
 import com.d3.commons.sidechain.iroha.util.getSetDetailCommands
+import com.d3.commons.sidechain.iroha.util.getSetDetailCommandsWithCreator
 import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.failure
@@ -92,10 +94,10 @@ class BtcNotaryInitialization(
                 depositServiceExpansion.expand(block)
             }
             irohaObservable.subscribe { (block, _) ->
-                getSetDetailCommands(block).map { it.setAccountDetail }
-                    .forEach { setAccountDetailCommand ->
+                getSetDetailCommandsWithCreator(block).map { SetAccountDetailEvent(it.command.setAccountDetail, it.creator) }
+                    .forEach { setAccountDetailEvent ->
                         accountDetailHandlers.forEach { handler ->
-                            handler.handleFiltered(setAccountDetailCommand)
+                            handler.handleFiltered(setAccountDetailEvent)
                         }
                     }
             }

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/BroadcastTransactionHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/BroadcastTransactionHandler.kt
@@ -5,13 +5,13 @@
 
 package com.d3.btc.withdrawal.handler
 
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.service.BtcWithdrawalFinalizeService
 import com.d3.btc.withdrawal.transaction.WithdrawalDetails
 import com.d3.commons.util.GsonInstance
 import com.d3.commons.util.irohaUnEscape
-import iroha.protocol.Commands
 import mu.KLogging
 import org.springframework.stereotype.Component
 
@@ -28,10 +28,11 @@ class BroadcastTransactionHandler(
 
     /**
      * Handles 'broadcast' events
-     * @param command - command with broadcast details
+     * @param setAccountDetailEvent - event with broadcast details
      */
-    override fun handle(command: Commands.SetAccountDetail) {
-        val withdrawalDetails = gson.fromJson(command.value.irohaUnEscape(), WithdrawalDetails::class.java)
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val withdrawalDetails =
+            gson.fromJson(setAccountDetailEvent.command.value.irohaUnEscape(), WithdrawalDetails::class.java)
         if (withdrawalDetails == null) {
             logger.error("Cannot handle 'null' withdrawal")
             return
@@ -43,8 +44,9 @@ class BroadcastTransactionHandler(
             )
     }
 
-    override fun filter(command: Commands.SetAccountDetail) =
-        command.accountId == btcWithdrawalConfig.broadcastsCredential.accountId
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId == btcWithdrawalConfig.broadcastsCredential.accountId &&
+                setAccountDetailEvent.creator == btcWithdrawalConfig.broadcastsCredential.accountId
 
     companion object : KLogging()
 }

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewBtcChangeAddressWithdrawalHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewBtcChangeAddressWithdrawalHandler.kt
@@ -5,6 +5,7 @@
 
 package com.d3.btc.withdrawal.handler
 
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
@@ -27,19 +28,20 @@ class NewBtcChangeAddressWithdrawalHandler(
 
     /**
      * Handles change address creation event
-     * @param command - Iroha command with change address details
+     * @param setAccountDetailEvent - Iroha event with change address details
      */
-    override fun handle(command: Commands.SetAccountDetail) {
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
         //Make new change address watched
         transfersWallet.addWatchedAddress(
             Address.fromBase58(
                 btcNetworkConfigProvider.getConfig(),
-                command.key
+                setAccountDetailEvent.command.key
             )
         )
     }
 
-    override fun filter(command: Commands.SetAccountDetail) =
-        command.accountId == btcWithdrawalConfig.changeAddressesStorageAccount
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId == btcWithdrawalConfig.changeAddressesStorageAccount &&
+                setAccountDetailEvent.creator == btcWithdrawalConfig.mstRegistrationAccount
 
 }

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewConsensusDataHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewConsensusDataHandler.kt
@@ -6,15 +6,16 @@
 package com.d3.btc.withdrawal.handler
 
 import com.d3.btc.config.BTC_CONSENSUS_DOMAIN
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.helper.address.getSignThreshold
+import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.provider.WithdrawalConsensusProvider
 import com.d3.btc.withdrawal.service.BtcRollbackService
 import com.d3.btc.withdrawal.service.WithdrawalTransferService
 import com.d3.btc.withdrawal.transaction.WithdrawalConsensus
 import com.d3.btc.withdrawal.transaction.WithdrawalDetails
 import com.d3.commons.util.irohaUnEscape
-import iroha.protocol.Commands
 import mu.KLogging
 import org.springframework.stereotype.Component
 
@@ -25,17 +26,18 @@ import org.springframework.stereotype.Component
 class NewConsensusDataHandler(
     private val withdrawalTransferService: WithdrawalTransferService,
     private val withdrawalConsensusProvider: WithdrawalConsensusProvider,
-    private val btcRollbackService: BtcRollbackService
+    private val btcRollbackService: BtcRollbackService,
+    private val btcWithdrawalConfig: BtcWithdrawalConfig
 ) : SetAccountDetailHandler() {
 
     /**
      * Handles new consensus command
-     * @param command - new consensus command
+     * @param setAccountDetailEvent - new consensus event
      */
-    override fun handle(command: Commands.SetAccountDetail) {
-        val withdrawalHash = command.accountId.replace("@$BTC_CONSENSUS_DOMAIN", "")
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val withdrawalHash = setAccountDetailEvent.command.accountId.replace("@$BTC_CONSENSUS_DOMAIN", "")
         val withdrawalConsensus =
-            WithdrawalConsensus.fromJson(command.value.irohaUnEscape())
+            WithdrawalConsensus.fromJson(setAccountDetailEvent.command.value.irohaUnEscape())
         withdrawalConsensusProvider.hasBeenEstablished(withdrawalHash).fold({ established ->
             if (established) {
                 logger.info("Withdrawal consensus has been already established")
@@ -67,7 +69,9 @@ class NewConsensusDataHandler(
         })
     }
 
-    override fun filter(command: Commands.SetAccountDetail) = command.accountId.endsWith("@$BTC_CONSENSUS_DOMAIN")
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId.endsWith("@$BTC_CONSENSUS_DOMAIN") &&
+                setAccountDetailEvent.creator == btcWithdrawalConfig.btcConsensusCredential.accountId
 
     /**
      * Logger

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewSignatureEventHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewSignatureEventHandler.kt
@@ -6,6 +6,7 @@
 package com.d3.btc.withdrawal.handler
 
 import com.d3.btc.config.BTC_SIGN_COLLECT_DOMAIN
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.provider.BroadcastsProvider
@@ -56,13 +57,11 @@ class NewSignatureEventHandler(
     }
 
     /**
-     * Handles "add new input signatures" commands
-     * @param command - command object full of signatures
+     * Handles "add new input signatures" events
+     * @param setAccountDetailEvent - event object full of signatures
      */
-    override fun handle(
-        command: Commands.SetAccountDetail
-    ) {
-        val shortTxHash = command.accountId.replace("@$BTC_SIGN_COLLECT_DOMAIN", "")
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val shortTxHash = setAccountDetailEvent.command.accountId.replace("@$BTC_SIGN_COLLECT_DOMAIN", "")
         var savedWithdrawal: WithdrawalDetails? = null
         var savedTx: Transaction? = null
         transactionsStorage.get(shortTxHash).map { withdrawal ->
@@ -154,7 +153,9 @@ class NewSignatureEventHandler(
         })
     }
 
-    override fun filter(command: Commands.SetAccountDetail) = command.accountId.endsWith("@$BTC_SIGN_COLLECT_DOMAIN")
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId.endsWith("@$BTC_SIGN_COLLECT_DOMAIN") &&
+                setAccountDetailEvent.creator == btcWithdrawalConfig.signatureCollectorCredential.accountId
 
     /**
      * Logger

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
@@ -1,6 +1,6 @@
 package com.d3.btc.withdrawal.handler
 
-import com.d3.btc.config.BTC_SIGN_COLLECT_DOMAIN
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.provider.BroadcastsProvider
@@ -12,7 +12,6 @@ import com.d3.btc.withdrawal.transaction.WithdrawalDetails
 import com.github.kittinunf.result.failure
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
-import iroha.protocol.Commands
 import mu.KLogging
 import org.bitcoinj.core.Transaction
 import org.springframework.stereotype.Component
@@ -29,12 +28,10 @@ class NewTransactionCreatedHandler(
 
     /**
      * Handles "create new transaction" commands
-     * @param command - command object with created transaction
+     * @param setAccountDetailEvent - event object with created transaction
      */
-    override fun handle(
-        command: Commands.SetAccountDetail
-    ) {
-        val txHash = command.key
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
+        val txHash = setAccountDetailEvent.command.key
         var savedWithdrawalDetails: WithdrawalDetails? = null
         var savedTransaction: Transaction? = null
         transactionsStorage.get(txHash).map { (withdrawalDetails, transaction) ->
@@ -66,7 +63,9 @@ class NewTransactionCreatedHandler(
         }
     }
 
-    override fun filter(command: Commands.SetAccountDetail) = command.accountId == btcWithdrawalConfig.txStorageAccount
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent) =
+        setAccountDetailEvent.command.accountId == btcWithdrawalConfig.txStorageAccount &&
+                setAccountDetailEvent.creator == btcWithdrawalConfig.withdrawalCredential.accountId
 
     /**
      * Logger

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/init/BtcWithdrawalInitialization.kt
@@ -6,6 +6,7 @@
 package com.d3.btc.withdrawal.init
 
 import com.d3.btc.fee.CurrentFeeRate
+import com.d3.btc.handler.SetAccountDetailEvent
 import com.d3.btc.handler.SetAccountDetailHandler
 import com.d3.btc.healthcheck.HealthyService
 import com.d3.btc.helper.network.addPeerConnectionStatusListener
@@ -14,16 +15,13 @@ import com.d3.btc.peer.SharedPeerGroup
 import com.d3.btc.provider.BtcChangeAddressProvider
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.wallet.checkWalletNetwork
-import com.d3.btc.withdrawal.config.BTC_WITHDRAWAL_SERVICE_NAME
 import com.d3.btc.withdrawal.config.BtcWithdrawalConfig
 import com.d3.btc.withdrawal.expansion.WithdrawalServiceExpansion
 import com.d3.btc.withdrawal.handler.NewTransferHandler
-import com.d3.chainadapter.client.RMQConfig
 import com.d3.chainadapter.client.ReliableIrohaChainListener
 import com.d3.commons.sidechain.iroha.FEE_DESCRIPTION
-import com.d3.commons.sidechain.iroha.util.getSetDetailCommands
+import com.d3.commons.sidechain.iroha.util.getSetDetailCommandsWithCreator
 import com.d3.commons.sidechain.iroha.util.getWithdrawalTransactions
-import com.d3.commons.util.createPrettySingleThreadPool
 import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.flatMap
 import com.github.kittinunf.result.map
@@ -115,10 +113,10 @@ class BtcWithdrawalInitialization(
             }
         }
         // Handle other commands
-        getSetDetailCommands(block).map { it.setAccountDetail }
-            .forEach { setAccountDetailCommand ->
+        getSetDetailCommandsWithCreator(block).map { SetAccountDetailEvent(it.command.setAccountDetail, it.creator) }
+            .forEach { setAccountDetailEvent ->
                 accountDetailHandlers.forEach { handler ->
-                    handler.handleFiltered(setAccountDetailCommand)
+                    handler.handleFiltered(setAccountDetailEvent)
                 }
             }
     }

--- a/btc/build.gradle
+++ b/btc/build.gradle
@@ -8,9 +8,12 @@ buildscript {
 apply plugin: "kotlin-spring" // See https://kotlinlang.org/docs/reference/compiler-plugins.html#kotlin-spring-compiler-plugin
 
 dependencies {
-    compile "com.github.d3ledger:reverse-chain-adapter:$reverse_chain_adapter_version"
     //TODO change version after D3 release
     compile "com.github.d3ledger.notary:notary-commons:$notary_version"
+
+    compile ("com.github.d3ledger:reverse-chain-adapter:$reverse_chain_adapter_version"){
+        exclude group: 'com.github.d3ledger.notary', module: 'notary-commons'
+    }
     // Chain adapter
     compile "com.github.soramitsu.chain-adapter:chain-adapter-client:$chain_adapter_client_version"
     //bitcoin

--- a/btc/src/main/kotlin/com/d3/btc/handler/NewBtcClientRegistrationHandler.kt
+++ b/btc/src/main/kotlin/com/d3/btc/handler/NewBtcClientRegistrationHandler.kt
@@ -9,7 +9,6 @@ import com.d3.btc.provider.account.BTC_CURRENCY_NAME_KEY
 import com.d3.btc.provider.network.BtcNetworkConfigProvider
 import com.d3.btc.storage.BtcAddressStorage
 import com.d3.commons.sidechain.iroha.CLIENT_DOMAIN
-import iroha.protocol.Commands
 import mu.KLogging
 import org.bitcoinj.core.Address
 import org.bitcoinj.wallet.Wallet
@@ -30,26 +29,26 @@ class NewBtcClientRegistrationHandler(
     /**
      * Handles newly registered Bitcoin addresses and adds addresses to current wallet object
      */
-    override fun handle(command: Commands.SetAccountDetail) {
+    override fun handle(setAccountDetailEvent: SetAccountDetailEvent) {
         val address = Address.fromBase58(
             btcNetworkConfigProvider.getConfig(),
-            command.value
+            setAccountDetailEvent.command.value
         )
         //Add new registered address to wallet
         if (wallet.addWatchedAddress(address)) {
-            logger.info { "New BTC address ${command.value} was added to wallet" }
+            logger.info { "New BTC address ${setAccountDetailEvent.command.value} was added to wallet" }
         } else {
             logger.error { "Address $address was not added to wallet" }
         }
-        btcAddressStorage.addClientAddress(address = address.toBase58(), accountId = command.accountId)
+        btcAddressStorage.addClientAddress(address = address.toBase58(), accountId = setAccountDetailEvent.command.accountId)
     }
 
     /**
      * Checks if new btc client was registered
      */
-    override fun filter(command: Commands.SetAccountDetail): Boolean {
-        return command.accountId.endsWith("@$CLIENT_DOMAIN")
-                && command.key == BTC_CURRENCY_NAME_KEY
+    override fun filter(setAccountDetailEvent: SetAccountDetailEvent): Boolean {
+        return setAccountDetailEvent.command.accountId.endsWith("@$CLIENT_DOMAIN")
+                && setAccountDetailEvent.command.key == BTC_CURRENCY_NAME_KEY
     }
 
     /**

--- a/btc/src/main/kotlin/com/d3/btc/handler/SetAccountDetailHandler.kt
+++ b/btc/src/main/kotlin/com/d3/btc/handler/SetAccountDetailHandler.kt
@@ -12,25 +12,30 @@ import iroha.protocol.Commands
 abstract class SetAccountDetailHandler {
 
     /**
-     * Handles commands if it is a command of our interest
-     * @param command - command to handle
+     * Handles events if it is a command of our interest
+     * @param setAccountDetailEvent - event to handle
      */
-    fun handleFiltered(command: Commands.SetAccountDetail) {
-        if (filter(command)) {
-            handle(command)
+    fun handleFiltered(setAccountDetailEvent: SetAccountDetailEvent) {
+        if (filter(setAccountDetailEvent)) {
+            handle(setAccountDetailEvent)
         }
     }
 
     /**
      * Handling logic
-     * @param command - command to handle
+     * @param setAccountDetailEvent - event to handle
      */
-    protected abstract fun handle(command: Commands.SetAccountDetail)
+    protected abstract fun handle(setAccountDetailEvent: SetAccountDetailEvent)
 
     /**
      * Filter of commands. Only filtered commands will be handled
-     * @param command - command to filter
+     * @param setAccountDetailEvent - event to filter
      * @return true if command if suitable for handling
      */
-    protected abstract fun filter(command: Commands.SetAccountDetail): Boolean
+    protected abstract fun filter(setAccountDetailEvent: SetAccountDetailEvent): Boolean
 }
+
+/**
+ * Data class that represents 'SetAccountDetail' command alongside with its creator
+ */
+data class SetAccountDetailEvent(val command: Commands.SetAccountDetail, val creator: String)

--- a/btc/src/main/kotlin/com/d3/btc/provider/generation/BtcPublicKeyProvider.kt
+++ b/btc/src/main/kotlin/com/d3/btc/provider/generation/BtcPublicKeyProvider.kt
@@ -17,7 +17,6 @@ import com.github.kittinunf.result.Result
 import com.github.kittinunf.result.map
 import mu.KLogging
 import org.bitcoinj.wallet.Wallet
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
 
@@ -34,17 +33,17 @@ import org.springframework.stereotype.Component
  */
 @Component
 class BtcPublicKeyProvider(
-    @Autowired private val keysWallet: Wallet,
-    @Autowired private val notaryPeerListProvider: NotaryPeerListProvider,
+    private val keysWallet: Wallet,
+    private val notaryPeerListProvider: NotaryPeerListProvider,
     @Qualifier("notaryAccount")
-    @Autowired private val notaryAccount: String,
+    private val notaryAccount: String,
     @Qualifier("changeAddressStorageAccount")
-    @Autowired private val changeAddressStorageAccount: String,
+    private val changeAddressStorageAccount: String,
     @Qualifier("multiSigConsumer")
-    @Autowired private val multiSigConsumer: IrohaConsumer,
+    private val multiSigConsumer: IrohaConsumer,
     @Qualifier("sessionConsumer")
-    @Autowired private val sessionConsumer: IrohaConsumer,
-    @Autowired private val btcNetworkConfigProvider: BtcNetworkConfigProvider
+    private val sessionConsumer: IrohaConsumer,
+    private val btcNetworkConfigProvider: BtcNetworkConfigProvider
 ) {
     init {
         logger.info { "BtcPublicKeyProvider was successfully initialized" }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.21'
     ext.ktor_version = '1.0.0'
-    ext.notary_version = '1b12c3f0d6'
+    ext.notary_version = 'dd204676ce3c5b68a88e9d147e33ba83861eda4d'
     ext.chain_adapter_client_version= '0dccefacf28b75b9e52022d785f57fe9f41638ae'
     ext.reverse_chain_adapter_version='83162b66c99b2821be326477e9c78a2c5e50efeb'
     repositories {

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcAddressGenerationTestEnvironment.kt
@@ -91,7 +91,7 @@ class BtcAddressGenerationTestEnvironment(
     }
 
     val triggerProvider = TriggerProvider(
-        integrationHelper.testCredential,
+        integrationHelper.accountHelper.registrationAccount,
         irohaApi,
         btcGenerationConfig.pubKeyTriggerAccount
     )

--- a/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
+++ b/notary-btc-integration-test/src/integration-test/kotlin/integration/btc/environment/BtcWithdrawalTestEnvironment.kt
@@ -334,7 +334,12 @@ class BtcWithdrawalTestEnvironment(
     private val broadcastTransactionHandler = BroadcastTransactionHandler(btcWithdrawalConfig, btcWithdrawalFinalizer)
 
     private val newConsensusDataHandler =
-        NewConsensusDataHandler(withdrawalTransferService, withdrawalConsensusProvider, btcRollbackService)
+        NewConsensusDataHandler(
+            withdrawalTransferService,
+            withdrawalConsensusProvider,
+            btcRollbackService,
+            btcWithdrawalConfig
+        )
 
     private val newTransactionCreatedHandler =
         NewTransactionCreatedHandler(


### PR DESCRIPTION
It's important to check the creator of commands in `SetAccountDetailHandler`s, otherwise, malicious nodes may take advantage of it. 