### PR TITLE
Making idempotent

### DIFF
--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandler.kt
@@ -46,7 +46,7 @@ class NewTransactionCreatedHandler(
             }
             val transaction = savedTransaction!!
             logger.info { "Tx to sign\n$savedTransaction" }
-            signCollector.signAndSave(transaction, btcWithdrawalConfig.btcKeysWalletPath)
+            signCollector.signAndSave(savedWithdrawalDetails!!, transaction, btcWithdrawalConfig.btcKeysWalletPath)
         }.map {
             logger.info { "Signatures for ${savedTransaction!!.hashAsString} were successfully processed" }
         }.failure { ex ->

--- a/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/SignCollector.kt
+++ b/btc-withdrawal/src/main/kotlin/com/d3/btc/withdrawal/transaction/SignCollector.kt
@@ -17,7 +17,6 @@ import com.d3.commons.notary.IrohaTransaction
 import com.d3.commons.sidechain.iroha.consumer.IrohaConsumer
 import com.d3.commons.sidechain.iroha.consumer.IrohaConverter
 import com.d3.commons.sidechain.iroha.util.IrohaQueryHelper
-import com.d3.commons.sidechain.iroha.util.ModelUtil
 import com.d3.commons.util.irohaEscape
 import com.d3.commons.util.toHexString
 import com.d3.commons.util.unHex
@@ -37,6 +36,7 @@ import org.bitcoinj.script.ScriptBuilder
 import org.bitcoinj.wallet.Wallet
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Component
+import java.math.BigInteger
 import kotlin.math.min
 
 /*
@@ -66,10 +66,15 @@ class SignCollector(
      * 1) Sign tx
      * 2) Create special account named after tx hash for signature storing
      * 3) Save signatures in recently created account details
+     * @param withdrawalDetails - details of withdrawal
      * @param tx - transaction to sign
      * @param walletPath - path to current wallet. Used to get private keys
      */
-    fun signAndSave(tx: Transaction, walletPath: String): Result<Unit, Exception> {
+    fun signAndSave(
+        withdrawalDetails: WithdrawalDetails,
+        tx: Transaction,
+        walletPath: String
+    ): Result<Unit, Exception> {
         return transactionSigner.sign(tx, walletPath).flatMap { signedInputs ->
             if (signedInputs.isEmpty()) {
                 logger.warn(
@@ -80,7 +85,7 @@ class SignCollector(
             }
             logger.info { "Tx ${tx.hashAsString} signatures to add in Iroha $signedInputs" }
             val shortTxHash = tx.shortTxHash()
-            val createAccountTx = IrohaConverter.convert(createSignCollectionAccountTx(shortTxHash))
+            val createAccountTx = IrohaConverter.convert(createSignCollectionAccountTx(shortTxHash, withdrawalDetails))
             /**
              * We create a dedicated account on every withdrawal event.
              * We need this account to store transaction signatures from all the nodes.
@@ -89,7 +94,7 @@ class SignCollector(
              */
             signatureCollectorConsumer.send(createAccountTx)
             val setSignaturesTx =
-                IrohaConverter.convert(setSignatureDetailsTx(shortTxHash, signedInputs))
+                IrohaConverter.convert(setSignatureDetailsTx(shortTxHash, signedInputs, withdrawalDetails))
             signatureCollectorConsumer.send(setSignaturesTx)
         }.map { Unit }
     }
@@ -223,10 +228,13 @@ class SignCollector(
     }
 
     //Creates Iroha transaction to create signature storing account
-    private fun createSignCollectionAccountTx(txShortHash: String): IrohaTransaction {
+    private fun createSignCollectionAccountTx(
+        txShortHash: String,
+        withdrawalDetails: WithdrawalDetails
+    ): IrohaTransaction {
         return IrohaTransaction(
             signatureCollectorConsumer.creator,
-            ModelUtil.getCurrentTime(),
+            BigInteger.valueOf(withdrawalDetails.withdrawalTime),
             1,
             arrayListOf(
                 IrohaCommand.CommandCreateAccount(
@@ -242,18 +250,21 @@ class SignCollector(
     @KtorExperimentalAPI
     private fun setSignatureDetailsTx(
         txShortHash: String,
-        signedInputs: List<InputSignature>
+        signedInputs: List<InputSignature>,
+        withdrawalDetails: WithdrawalDetails
     ): IrohaTransaction {
         val signCollectionAccountId = "$txShortHash@$BTC_SIGN_COLLECT_DOMAIN"
         val signaturesJson = inputSignatureJsonAdapter.toJson(signedInputs).irohaEscape()
         val hexes = StringBuilder()
-        signedInputs.forEach { inputSignature ->
-            hexes.append(inputSignature.sigPubKey.signatureHex)
-        }
+        signedInputs
+            .sortedBy { inputSignature -> inputSignature.sigPubKey.pubKey }
+            .forEach { inputSignature ->
+                hexes.append(inputSignature.sigPubKey.pubKey)
+            }
         val signaturesHash = Utils.toHex(sha1(hexes.toString().toByteArray()))
         return IrohaTransaction(
             signatureCollectorConsumer.creator,
-            ModelUtil.getCurrentTime(),
+            BigInteger.valueOf(withdrawalDetails.withdrawalTime),
             1,
             arrayListOf(
                 IrohaCommand.CommandSetAccountDetail(

--- a/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandlerTest.java
+++ b/btc-withdrawal/src/test/java/com/d3/btc/withdrawal/handler/NewTransactionCreatedHandlerTest.java
@@ -59,13 +59,13 @@ public class NewTransactionCreatedHandlerTest {
      */
     @Test
     public void testHandleHasBeenBroadcasted() {
+        WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
+                "source account",
+                "destination address",
+                1,
+                System.currentTimeMillis(),
+                0);
         when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> {
-            WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
-                    "source account",
-                    "destination address",
-                    1,
-                    System.currentTimeMillis(),
-                    0);
             Transaction transaction = mock(Transaction.class);
             return new Pair<>(withdrawalDetails, transaction);
         }));
@@ -73,7 +73,7 @@ public class NewTransactionCreatedHandlerTest {
         Commands.SetAccountDetail createdTxCommand = Commands.SetAccountDetail.newBuilder().setKey("abc").build();
         SetAccountDetailEvent event = new SetAccountDetailEvent(createdTxCommand, withdrawalAccountId);
         newTransactionCreatedHandler.handle(event);
-        verify(signCollector, never()).signAndSave(any(), any());
+        verify(signCollector, never()).signAndSave(eq(withdrawalDetails), any(), any());
     }
 
     /**
@@ -83,13 +83,13 @@ public class NewTransactionCreatedHandlerTest {
      */
     @Test
     public void testHandleHasNotBeenBroadcasted() {
+        WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
+                "source account",
+                "destination address",
+                1,
+                System.currentTimeMillis(),
+                0);
         when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> {
-            WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
-                    "source account",
-                    "destination address",
-                    1,
-                    System.currentTimeMillis(),
-                    0);
             Transaction transaction = mock(Transaction.class);
             return new Pair<>(withdrawalDetails, transaction);
         }));
@@ -97,7 +97,7 @@ public class NewTransactionCreatedHandlerTest {
         Commands.SetAccountDetail createdTxCommand = Commands.SetAccountDetail.newBuilder().setKey("abc").build();
         SetAccountDetailEvent event = new SetAccountDetailEvent(createdTxCommand, withdrawalAccountId);
         newTransactionCreatedHandler.handle(event);
-        verify(signCollector).signAndSave(any(), any());
+        verify(signCollector).signAndSave(eq(withdrawalDetails), any(), any());
     }
 
     /**
@@ -107,13 +107,13 @@ public class NewTransactionCreatedHandlerTest {
      */
     @Test
     public void testHandleBroadcastFail() {
+        WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
+                "source account",
+                "destination address",
+                1,
+                System.currentTimeMillis(),
+                0);
         when(transactionsStorage.get(anyString())).thenReturn(Result.Companion.of(() -> {
-            WithdrawalDetails withdrawalDetails = new WithdrawalDetails(
-                    "source account",
-                    "destination address",
-                    1,
-                    System.currentTimeMillis(),
-                    0);
             Transaction transaction = mock(Transaction.class);
             return new Pair<>(withdrawalDetails, transaction);
         }));
@@ -124,7 +124,7 @@ public class NewTransactionCreatedHandlerTest {
         Commands.SetAccountDetail createdTxCommand = Commands.SetAccountDetail.newBuilder().setKey("abc").build();
         SetAccountDetailEvent event = new SetAccountDetailEvent(createdTxCommand, withdrawalAccountId);
         newTransactionCreatedHandler.handle(event);
-        verify(signCollector, never()).signAndSave(any(), any());
+        verify(signCollector, never()).signAndSave(eq(withdrawalDetails), any(), any());
         verify(btcRollbackService).rollback(any(WithdrawalDetails.class), any());
         verify(utxoProvider).unregisterUnspents(any(), any());
     }


### PR DESCRIPTION
We have to use a withdrawal time in transactions instead of the current time to make the withdrawal service more idempotent.